### PR TITLE
feat(new command): updates new to download multiple file templates

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -5,10 +5,9 @@ import prompts from 'prompts';
 import { Merge } from 'type-fest';
 import { Arguments, Argv } from 'yargs';
 import checkProjectStructure from '../checks/project-structure';
-import { fetchListOfTemplates, getTemplateFiles } from '../templating/data';
-import { writeFiles } from '../templating/filesystem';
 import { CliInfo } from './types';
 import { getFullCommand } from './utils';
+import { downloadTemplate, fetchListOfTemplates } from '../templating/actions';
 
 export type NewCliFlags = Arguments<{
   filename?: string;
@@ -129,14 +128,9 @@ export async function handler(flagsInput: NewCliFlags): Promise<void> {
     return;
   }
 
-  const functionName = flags.filename.replace(/\.js$/, '');
-  const files = await getTemplateFiles(flags.template, functionName);
-  try {
-    await writeFiles(files, targetDirectory, functionName);
-    console.log(chalk`{green SUCCESS} Created new function ${functionName}`);
-  } catch (err) {
-    console.error(chalk`{red ERROR} ${err.message}`);
-  }
+  const bundleName = flags.filename.replace(/\.js$/, '');
+
+  downloadTemplate(flags.template, bundleName, targetDirectory);
 }
 
 export const cliInfo: CliInfo = {

--- a/src/templating/actions.ts
+++ b/src/templating/actions.ts
@@ -1,0 +1,19 @@
+import { getTemplateFiles } from './data';
+import { writeFiles } from './filesystem';
+import chalk from 'chalk';
+
+export async function downloadTemplate(
+  templateName: string,
+  bundleName: string,
+  targetDirectory: string
+): Promise<void> {
+  const files = await getTemplateFiles(templateName);
+  try {
+    await writeFiles(files, targetDirectory, bundleName);
+    console.log(chalk`{green SUCCESS} Created new bundle ${bundleName}`);
+  } catch (err) {
+    console.error(chalk`{red ERROR} ${err.message}`);
+  }
+}
+
+export { fetchListOfTemplates } from './data';


### PR DESCRIPTION
Uses the new layout of the functions-templates project to download multiple file templates into a
twilio-run project. Templates will be downloaded into the functions/{bundleName} and
assets/{bundleName} directories within the project.

This also allows for passing an empty bundleName (or filename in the twilio-run CLI parlance right
 now). When empty, this adds the functions/assets directly into the functions/assets directories.
This will be used for `create-twilio-function` template options. The twilio-run CLI still enforces
a name.

BREAKING CHANGE: This needs the functions-templates repo to be up to date. Currently it points to
the next branch, which is up to date.

re #20

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
