### PR TITLE
fix: removes console.error

### DIFF
--- a/src/templating/data.ts
+++ b/src/templating/data.ts
@@ -100,7 +100,6 @@ export async function getTemplateFiles(
     return files;
   } catch (err) {
     log(err.message);
-    console.error(err);
     throw new Error('Invalid template');
   }
 }


### PR DESCRIPTION
When downloading a template that doesn't exist the error was printed in full to the command line.
This fixes that and solves some of the issue with [create-twilio-function#19](https://github.com/twilio-labs/create-twilio-function/pull/19)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
