### PR TITLE
refactor: Splits list-templates command from new --list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@
     - [Examples](#examples)
   - [`twilio-run deploy`](#twilio-run-deploy)
     - [Examples](#examples-1)
-  - [`twilio-run new [namespace]`](#twilio-run-new-namespace)
+  - [`twilio-run list-templates`](#twilio-run-list-templates)
     - [Examples](#examples-2)
-  - [`twilio-run list [types]`](#twilio-run-list-types)
+- [`twilio-run new [namespace]`](#twilio-run-new-namespace)
     - [Examples](#examples-3)
-  - [`twilio-run activate`](#twilio-run-activate)
+  - [`twilio-run list [types]`](#twilio-run-list-types)
     - [Examples](#examples-4)
+  - [`twilio-run activate`](#twilio-run-activate)
+    - [Examples](#examples-5)
 - [API](#api)
   - [`runDevServer(port: number, baseDir: string): Promise<Express.Application>`](#rundevserverport-number-basedir-string-promiseexpressapplication)
   - [`handleToExpressRoute(handler: TwilioHandlerFunction): Express.RequestHandler`](#handletoexpressroutehandler-twiliohandlerfunction-expressrequesthandler)
@@ -108,16 +110,24 @@ twilio-run deploy
 twilio-run deploy --environment=prod
 ```
 
-### `twilio-run new [namespace]`
+### `twilio-run list-templates`
 
-Creates a new set of functions and/or assets inside your current project based on a [template](https://github.com/twilio-labs/function-templates). Alternatively it can list all available templates using the `--list` flag.
+Lists the [templates available](https://github.com/twilio-labs/function-templates) to that you can use to generate new functions and/or assets inside your current project with the [`twilio-run new` command](#twilio-run-new-namespace) below.
 
 #### Examples
 
 ```bash
 # List available templates
-twilio-run new --list
+twilio-run list-templates
+```
 
+### `twilio-run new [namespace]`
+
+Creates a new set of functions and/or assets inside your current project based on a [template](https://github.com/twilio-labs/function-templates).
+
+#### Examples
+
+```bash
 # Create a new function using the blank template
 # in a subfolder (namespace) demo
 twilio-run new demo --template=blank
@@ -153,7 +163,7 @@ Promotes an existing deployment to a new environment. It can also create a new e
 
 ```bash
 # Promotes the same build that is on the "dev" environment to the "prod" environment
-twilio-run activate --environment=prod --source-environment=dev  
+twilio-run activate --environment=prod --source-environment=dev
 # Duplicates an existing build to a new environment called `demo`
 twilio-run activate --environment=demo --create-environment --build-sid=ZB1234xxxxxxxxxx
 ```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,14 +4,16 @@ import * as DeployCommand from './commands/deploy';
 import * as ListCommand from './commands/list';
 import * as NewCommand from './commands/new';
 import * as StartCommand from './commands/start';
+import * as ListTemplatesCommand from './commands/list-templates';
 import './utils/debug';
 
 export async function run(rawArgs: string[]) {
   yargs
+    .command(StartCommand)
     .command(NewCommand)
+    .command(ListTemplatesCommand)
     .command(DeployCommand)
     .command(ListCommand)
     .command(ActivateCommand)
-    .command(StartCommand)
     .parse(rawArgs.slice(2));
 }

--- a/src/commands/list-templates.ts
+++ b/src/commands/list-templates.ts
@@ -1,0 +1,30 @@
+import chalk from 'chalk';
+import ora from 'ora';
+import { Argv } from 'yargs';
+import { fetchListOfTemplates } from '../templating/actions';
+import { CliInfo } from './types';
+
+export async function handler(): Promise<void> {
+  const spinner = ora('Fetching available templates').start();
+
+  let templates;
+  try {
+    templates = await fetchListOfTemplates();
+  } catch (err) {
+    spinner.fail('Failed to retrieve templates');
+    process.exitCode = 1;
+    return;
+  }
+
+  spinner.stop();
+
+  templates.forEach(template => {
+    console.log(
+      chalk`‣ ${template.name} ({cyan ${template.id}})\n  {dim ${template.description}}`
+    );
+  });
+}
+
+export const cliInfo: CliInfo = { options: {} };
+export const command = ['list-templates'];
+export const describe = 'Lists the available Twilio Function templates';


### PR DESCRIPTION
This will let us share the list-templates command with other projects and the CLI plugin more easily.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
