### PR TITLE
refactor: renames "bundle" to "namespace" when downloading templates

### DIFF
--- a/src/templating/actions.ts
+++ b/src/templating/actions.ts
@@ -4,13 +4,15 @@ import chalk from 'chalk';
 
 export async function downloadTemplate(
   templateName: string,
-  bundleName: string,
+  namespace: string,
   targetDirectory: string
 ): Promise<void> {
   const files = await getTemplateFiles(templateName);
   try {
-    await writeFiles(files, targetDirectory, bundleName);
-    console.log(chalk`{green SUCCESS} Created new bundle ${bundleName}`);
+    await writeFiles(files, targetDirectory, namespace);
+    console.log(
+      chalk`{green SUCCESS} Downloaded new template into the "${namespace}" subdirectories`
+    );
   } catch (err) {
     console.error(chalk`{red ERROR} ${err.message}`);
   }

--- a/src/templating/filesystem.ts
+++ b/src/templating/filesystem.ts
@@ -84,7 +84,7 @@ function hasFilesOfType(files: TemplateFileInfo[], type: string) {
 export async function writeFiles(
   files: TemplateFileInfo[],
   targetDir: string,
-  bundleName: string
+  namespace: string
 ): Promise<void> {
   const functionsDir = fsHelpers.getFirstMatchingDirectory(targetDir, [
     'functions',
@@ -94,8 +94,8 @@ export async function writeFiles(
     'assets',
     'static',
   ]);
-  const functionsTargetDir = path.join(functionsDir, bundleName);
-  const assetsTargetDir = path.join(assetsDir, bundleName);
+  const functionsTargetDir = path.join(functionsDir, namespace);
+  const assetsTargetDir = path.join(assetsDir, namespace);
 
   if (functionsTargetDir !== functionsDir) {
     if (hasFilesOfType(files, 'functions')) {
@@ -104,7 +104,7 @@ export async function writeFiles(
       } catch (err) {
         log(err);
         throw new Error(
-          `Bundle with name "${bundleName}" already exists in "${functionsDir}"`
+          `Template with name "${namespace}" already exists in "${functionsDir}"`
         );
       }
     }
@@ -115,7 +115,7 @@ export async function writeFiles(
       } catch (err) {
         log(err);
         throw new Error(
-          `Bundle with name "${bundleName}" already exists in "${assetsDir}"`
+          `Template with name "${namespace}" already exists in "${assetsDir}"`
         );
       }
     }


### PR DESCRIPTION
Namespace is a better name. This improves the output messaging as well.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
