### PR TITLE
chore: change project flag to profile

### DIFF
--- a/__tests__/config/utils/credentials.test.ts
+++ b/__tests__/config/utils/credentials.test.ts
@@ -103,6 +103,8 @@ describe('getCredentialsFromFlags', () => {
   });
 
   test('external options with project should override env variables', async () => {
+    // project flag is deprecated and removed in v3 @twilio/cli-core but
+    // included here just to make sure
     require('../../../src/config/utils/env').__setVariables(
       {
         ACCOUNT_SID: 'ACyyyyyyyyy',
@@ -112,8 +114,14 @@ describe('getCredentialsFromFlags', () => {
     );
 
     const credentials = await getCredentialsFromFlags(
-      { ...baseFlags },
-      { username: 'ACzzzzzzz', password: 'api-secret', project: 'demo' }
+      {
+        ...baseFlags,
+      },
+      {
+        username: 'ACzzzzzzz',
+        password: 'api-secret',
+        project: 'demo',
+      }
     );
     expect(credentials).toEqual({
       accountSid: 'ACzzzzzzz',
@@ -140,6 +148,27 @@ describe('getCredentialsFromFlags', () => {
     });
   });
 
+  test('should prefer external CLI if project is passed', async () => {
+    // project flag is deprecated and removed in v3 @twilio/cli-core but
+    // included here just to make sure
+    require('../../../src/config/utils/env').__setVariables(
+      {
+        ACCOUNT_SID: 'ACyyyyyyyyy',
+        AUTH_TOKEN: 'example-token',
+      },
+      ''
+    );
+
+    const credentials = await getCredentialsFromFlags(
+      { ...baseFlags },
+      { username: 'ACzzzzzzz', password: 'api-secret', project: 'demo' }
+    );
+    expect(credentials).toEqual({
+      accountSid: 'ACzzzzzzz',
+      authToken: 'api-secret',
+    });
+  });
+
   test('should prefer flag over everything', async () => {
     require('../../../src/config/utils/env').__setVariables(
       {
@@ -151,7 +180,12 @@ describe('getCredentialsFromFlags', () => {
 
     const credentials = await getCredentialsFromFlags(
       { ...baseFlags, accountSid: 'ACxxxxx', authToken: 'some-token' },
-      { username: 'ACzzzzzzz', password: 'api-secret', profile: 'demo' }
+      {
+        username: 'ACzzzzzzz',
+        password: 'api-secret',
+        profile: 'demo',
+        project: 'demo',
+      }
     );
     expect(credentials).toEqual({
       accountSid: 'ACxxxxx',

--- a/__tests__/config/utils/credentials.test.ts
+++ b/__tests__/config/utils/credentials.test.ts
@@ -7,7 +7,6 @@ const baseFlags = {
   cwd: process.cwd(),
   logLevel: 'info' as 'info',
 };
-const baseExternalCliOptions = {};
 
 describe('getCredentialsFromFlags', () => {
   test('should return empty if nothing is passed', async () => {
@@ -57,7 +56,7 @@ describe('getCredentialsFromFlags', () => {
 
     const credentials = await getCredentialsFromFlags(
       { ...baseFlags },
-      { username: 'ACzzzzzzz', password: 'api-secret', project: undefined }
+      { username: 'ACzzzzzzz', password: 'api-secret', profile: undefined }
     );
     expect(credentials).toEqual({
       accountSid: 'ACzzzzzzz',
@@ -76,11 +75,30 @@ describe('getCredentialsFromFlags', () => {
 
     const credentials = await getCredentialsFromFlags(
       { ...baseFlags },
-      { username: 'ACzzzzzzz', password: 'api-secret', project: undefined }
+      { username: 'ACzzzzzzz', password: 'api-secret', profile: undefined }
     );
     expect(credentials).toEqual({
       accountSid: 'ACyyyyyyyyy',
       authToken: 'example-token',
+    });
+  });
+
+  test('external options with profile should override env variables', async () => {
+    require('../../../src/config/utils/env').__setVariables(
+      {
+        ACCOUNT_SID: 'ACyyyyyyyyy',
+        AUTH_TOKEN: 'example-token',
+      },
+      ''
+    );
+
+    const credentials = await getCredentialsFromFlags(
+      { ...baseFlags },
+      { username: 'ACzzzzzzz', password: 'api-secret', profile: 'demo' }
+    );
+    expect(credentials).toEqual({
+      accountSid: 'ACzzzzzzz',
+      authToken: 'api-secret',
     });
   });
 
@@ -103,7 +121,7 @@ describe('getCredentialsFromFlags', () => {
     });
   });
 
-  test('should prefer external CLI if project is passed', async () => {
+  test('should prefer external CLI if profile is passed', async () => {
     require('../../../src/config/utils/env').__setVariables(
       {
         ACCOUNT_SID: 'ACyyyyyyyyy',
@@ -114,7 +132,7 @@ describe('getCredentialsFromFlags', () => {
 
     const credentials = await getCredentialsFromFlags(
       { ...baseFlags },
-      { username: 'ACzzzzzzz', password: 'api-secret', project: 'demo' }
+      { username: 'ACzzzzzzz', password: 'api-secret', profile: 'demo' }
     );
     expect(credentials).toEqual({
       accountSid: 'ACzzzzzzz',
@@ -133,7 +151,7 @@ describe('getCredentialsFromFlags', () => {
 
     const credentials = await getCredentialsFromFlags(
       { ...baseFlags, accountSid: 'ACxxxxx', authToken: 'some-token' },
-      { username: 'ACzzzzzzz', password: 'api-secret', project: 'demo' }
+      { username: 'ACzzzzzzz', password: 'api-secret', profile: 'demo' }
     );
     expect(credentials).toEqual({
       accountSid: 'ACxxxxx',

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -20,6 +20,7 @@ export type ExternalCliOptions = {
   username: string;
   password: string;
   accountSid?: string;
+  profile?: string;
   project?: string;
   logLevel?: string;
   outputFormat?: string;

--- a/src/config/utils/credentials.ts
+++ b/src/config/utils/credentials.ts
@@ -15,10 +15,11 @@ export type Credentials = {
 /**
  * Determines the credentials by the following order of preference:
  * 1. value via explicit flags
- * 2. value passed in through externalCliOptions if `project` exists
- * 3. value in .env file
- * 4. value passed in through externalCliOptions
- * 5. empty string
+ * 2. value passed in through externalCliOptions if `profile` exists
+ * 3. value passed in through externalCliOptions if `project` (deprecated and removed in `@twilio/cli-core` v3) exists
+ * 4. value in .env file
+ * 5. value passed in through externalCliOptions
+ * 6. empty string
  * @param flags Flags passed into command
  * @param externalCliOptions Any external information for example passed by the Twilio CLI
  */
@@ -28,12 +29,12 @@ export async function getCredentialsFromFlags<
   // default Twilio CLI credentials (4) or empty string (5)
   let accountSid =
     (externalCliOptions &&
-      !externalCliOptions.project &&
+      !(externalCliOptions.profile || externalCliOptions.project) &&
       externalCliOptions.username) ||
     '';
   let authToken =
     (externalCliOptions &&
-      !externalCliOptions.project &&
+      !(externalCliOptions.profile || externalCliOptions.project) &&
       externalCliOptions.password) ||
     '';
 
@@ -50,9 +51,12 @@ export async function getCredentialsFromFlags<
     }
   }
 
-  // specific project specified. override both credentials (2)
-  if (externalCliOptions && externalCliOptions.project) {
-    debug('Values read from explicit CLI project');
+  // specific profile specified. override both credentials (2)
+  if (
+    externalCliOptions &&
+    (externalCliOptions.profile || externalCliOptions.project)
+  ) {
+    debug('Values read from explicit CLI profile');
     accountSid = externalCliOptions.username;
     authToken = externalCliOptions.password;
   }


### PR DESCRIPTION
`@twilio/core-cli` renamed the `project` flag to `profile`. Since `twilio-run` doesn't depend on `@twilio/core-cli` but does ingest its flags for some commands, we need to update here.

`project` was kept as an alternative to `profile` for now. This can likely be removed at a later date.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
