### PR TITLE
fix(activate): environment was 'required' not 'requiresArg'

### DIFF
--- a/src/commands/activate.ts
+++ b/src/commands/activate.ts
@@ -93,7 +93,7 @@ export const cliInfo: CliInfo = {
     environment: {
       type: 'string',
       describe: 'The environment suffix or SID to deploy to.',
-      required: true,
+      requiresArg: true,
     },
     'account-sid': {
       type: 'string',


### PR DESCRIPTION
activate command had incorrect 'required' property which prevented treatment as a required argument when converted from yargs to oclif.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
