### PR TITLE
fix(debug): fix redaction of logger overwriting values

### DIFF
--- a/__tests__/utils/debug.test.ts
+++ b/__tests__/utils/debug.test.ts
@@ -1,0 +1,51 @@
+import { createRedactedObject, generalRedactor } from '../../src/utils/debug';
+
+describe('generalRedactor', () => {
+  test('redacts the correct properties', () => {
+    const context = {
+      ACCOUNT_SID: 'ACxxxxxxx',
+      AUTH_TOKEN: 'auth-token',
+      SOME_URL: 'https://twilio.com/labs',
+    };
+
+    const redacted = generalRedactor(context);
+    expect(redacted.ACCOUNT_SID).toBe('ACxxxxxxx');
+    expect(redacted.AUTH_TOKEN).toBe('[REDACTED]');
+    expect(redacted.SOME_URL).toBe('https://twilio.com/labs');
+  });
+});
+
+describe('createRedactedObject', () => {
+  test('does not modify the original object', () => {
+    const context = {
+      ACCOUNT_SID: 'ACxxxxxxx',
+      AUTH_TOKEN: 'auth-token',
+      SOME_URL: 'https://twilio.com/labs',
+      env: {
+        ACCOUNT_SID: 'ACyyyyyyy',
+        AUTH_TOKEN: 'another-auth-token',
+      },
+    };
+
+    const redacted = createRedactedObject(context, generalRedactor);
+
+    expect(redacted).toEqual({
+      ACCOUNT_SID: 'ACxxxxxxx',
+      AUTH_TOKEN: '[REDACTED]',
+      SOME_URL: 'https://twilio.com/labs',
+      env: {
+        ACCOUNT_SID: '[REDACTED]',
+        AUTH_TOKEN: '[REDACTED]',
+      },
+    });
+    expect(context).toEqual({
+      ACCOUNT_SID: 'ACxxxxxxx',
+      AUTH_TOKEN: 'auth-token',
+      SOME_URL: 'https://twilio.com/labs',
+      env: {
+        ACCOUNT_SID: 'ACyyyyyyy',
+        AUTH_TOKEN: 'another-auth-token',
+      },
+    });
+  });
+});

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -28,15 +28,29 @@ export const generalRedactor = fastRedact({
       'TWILIO_API_SECRET',
     ]),
   ],
-});
+  serialize: false,
+}) as <T>(x: T) => T;
 
 export const allPropertiesRedactor = fastRedact({
   paths: ['*'],
-});
+  serialize: false,
+}) as <T>(x: T) => T;
+
+export function copyObject(obj: object) {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+export function createRedactedObject(
+  obj: object,
+  redactor: typeof generalRedactor
+) {
+  const copiedObject = copyObject(obj);
+  return redactor(copiedObject);
+}
 
 debug.formatters.P = function protectedFormatterMultiline(v: any): string {
   if (typeof v === 'object') {
-    v = JSON.parse(generalRedactor(v));
+    v = createRedactedObject(v, generalRedactor);
   }
 
   return debug.formatters.O.bind(debug)(v);
@@ -44,7 +58,7 @@ debug.formatters.P = function protectedFormatterMultiline(v: any): string {
 
 debug.formatters.p = function protectedFormatterSameline(v: any): string {
   if (typeof v === 'object') {
-    v = JSON.parse(generalRedactor(v));
+    v = createRedactedObject(v, generalRedactor);
   }
 
   return debug.formatters.o.bind(debug)(v);
@@ -52,14 +66,14 @@ debug.formatters.p = function protectedFormatterSameline(v: any): string {
 
 debug.formatters.R = function redactedFormatterMultiline(v: any): string {
   if (typeof v === 'object') {
-    v = JSON.parse(allPropertiesRedactor(v));
+    v = createRedactedObject(v, allPropertiesRedactor);
   }
   return debug.formatters.O.bind(debug)(v);
 };
 
 debug.formatters.r = function redactedFormatterSameline(v: any): string {
   if (typeof v === 'object') {
-    v = JSON.parse(allPropertiesRedactor(v));
+    v = createRedactedObject(v, allPropertiesRedactor);
   }
   return debug.formatters.o.bind(debug)(v);
 };


### PR DESCRIPTION
As described by @ShelbyZ, the redaction apparently overrides the original object. I added tests to catch that going forward and fixed the behavior by copying the original object. I think that's a fine behavior because this is only happening when debug logs are enabled. Therefore performance is less of a concern.

fix #78

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
