### PR TITLE
fix(server): object Runtime not available before function run

### DIFF
--- a/src/runtime/route.ts
+++ b/src/runtime/route.ts
@@ -122,8 +122,6 @@ export function functionToRoute(
   config: StartCliConfig,
   functionFilePath?: string
 ): ExpressRequestHandler {
-  constructGlobalScope(config);
-
   return function twilioFunctionHandler(
     req: ExpressRequest,
     res: ExpressResponse,

--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -14,7 +14,7 @@ import { getDebugFunction } from '../utils/logger';
 import { createLogger } from './internal/request-logger';
 import { setRoutes } from './internal/route-cache';
 import { getFunctionsAndAssets } from './internal/runtime-paths';
-import { functionToRoute } from './route';
+import { functionToRoute, constructGlobalScope } from './route';
 
 const debug = getDebugFunction('twilio-run:server');
 const DEFAULT_PORT = process.env.PORT || 3000;
@@ -79,6 +79,8 @@ export async function createServer(
 
   const routes = await getFunctionsAndAssets(config.baseDir);
   const routeMap = setRoutes(routes);
+
+  constructGlobalScope(config);
 
   app.set('port', port);
   app.all(


### PR DESCRIPTION
It is possible to define a function that uses the Runtime prior to handler execution:

```JavaScript
const hello = require(Runtime.getFunctions()['hello'].path);

exports.handler = function(context, event, callback) {
    hello.handler(context, event, () => {
        console.log('ran');
        callback(null, {});
    });
};
```

The above code will work when deployed to Twilio, but not when hosted via twilio-run.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
