### PR TITLE
feat: add estimated execution time to function run

### DIFF
--- a/src/runtime/route.ts
+++ b/src/runtime/route.ts
@@ -147,17 +147,17 @@ export function functionToRoute(
     ) {
       run_timings.end = process.hrtime();
       debug('Function execution %s finished', req.path);
-      if (err) {
-        handleError(err, req, res, functionFilePath);
-        return;
-      }
-      handleSuccess(responseObject, res);
       debug(
         `(Estimated) Total Execution Time: ${(run_timings.end[0] * 1e9 +
           run_timings.end[1] -
           (run_timings.start[0] * 1e9 + run_timings.start[1])) /
           1e6}ms`
       );
+      if (err) {
+        handleError(err, req, res, functionFilePath);
+        return;
+      }
+      handleSuccess(responseObject, res);
     };
 
     debug('Calling function for %s', req.path);

--- a/src/runtime/route.ts
+++ b/src/runtime/route.ts
@@ -134,18 +134,18 @@ export function functionToRoute(
     const context = constructContext(config);
     debug('Context for %s: %p', req.path, context);
     let run_timings: {
-      start: bigint;
-      end: bigint;
+      start: [number, number];
+      end: [number, number];
     } = {
-      start: BigInt(0),
-      end: BigInt(0),
+      start: [0, 0],
+      end: [0, 0],
     };
 
     const callback: ServerlessCallback = function callback(
       err,
       responseObject?
     ) {
-      run_timings.end = process.hrtime.bigint();
+      run_timings.end = process.hrtime();
       debug('Function execution %s finished', req.path);
       if (err) {
         handleError(err, req, res, functionFilePath);
@@ -153,15 +153,16 @@ export function functionToRoute(
       }
       handleSuccess(responseObject, res);
       debug(
-        `(Estimated) Total Execution Time: ${Number(
-          run_timings.end - run_timings.start
-        ) / 1e6}ms`
+        `(Estimated) Total Execution Time: ${(run_timings.end[0] * 1e9 +
+          run_timings.end[1] -
+          (run_timings.start[0] * 1e9 + run_timings.start[1])) /
+          1e6}ms`
       );
     };
 
     debug('Calling function for %s', req.path);
     try {
-      run_timings.start = process.hrtime.bigint();
+      run_timings.start = process.hrtime();
       fn(context, event, callback);
     } catch (err) {
       callback(err);


### PR DESCRIPTION
- use process.hrtime() to track start/stop (supports nodeJS 8.x)
- debug log estimated execution time in milliseconds

Not sure if requiring debug() is the correct way to report this information.  We could also consider displaying a warning/error message if the estimated duration execeeds the defined limit.

Another approach to capturing timing would be to use perf_hooks to setup an observer and add measurements.  The observer could process the measurements (logging) and disconnect.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
