### PR TITLE
feat(templates): report GitHub api error

### DIFF
--- a/src/templating/actions.ts
+++ b/src/templating/actions.ts
@@ -8,8 +8,8 @@ export async function downloadTemplate(
   namespace: string,
   targetDirectory: string
 ): Promise<void> {
-  const files = await getTemplateFiles(templateName);
   try {
+    const files = await getTemplateFiles(templateName);
     await writeFiles(files, targetDirectory, namespace);
     logger.info(
       chalk`{green SUCCESS} Downloaded new template into the "${namespace}" subdirectories`

--- a/src/templating/data.ts
+++ b/src/templating/data.ts
@@ -47,6 +47,11 @@ type RawContentsPayload = {
   };
 }[];
 
+type GitHubError = {
+  message: string;
+  documentation_url?: string;
+};
+
 async function getFiles(
   templateId: string,
   directory: string
@@ -97,6 +102,14 @@ export async function getTemplateFiles(
     return files;
   } catch (err) {
     debug(err.message);
+
+    if (err.response) {
+      const bodyMessage = err.response.body as GitHubError;
+      throw new Error(
+        bodyMessage ? `${err.message}\n${bodyMessage.message}` : err.message
+      );
+    }
+
     throw new Error('Invalid template');
   }
 }


### PR DESCRIPTION
This change surfaces the descriptive message returned when an error is encountered using GitHub API to import templates. 

Tested with status 403 rate limited exceeded and 404 page not found. Suggestions welcome.

Fixes #68 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
