### PR TITLE
feat: allow the same namespace but different files

### DIFF
--- a/__tests__/templating/filesystem.test.ts
+++ b/__tests__/templating/filesystem.test.ts
@@ -1,0 +1,242 @@
+jest.mock('listr/lib/renderer');
+jest.mock('@twilio-labs/serverless-api');
+jest.mock('got');
+jest.mock('pkg-install');
+jest.mock('../../src/utils/fs');
+jest.mock('../../src/utils/logger');
+
+import path from 'path';
+import { install } from 'pkg-install';
+import { fsHelpers } from '@twilio-labs/serverless-api';
+import got from 'got';
+import { mocked } from 'ts-jest/utils';
+import { writeFiles } from '../../src/templating/filesystem';
+import { downloadFile, fileExists, readFile, writeFile, mkdir } from '../../src/utils/fs';
+
+beforeEach(() => {
+  // For our test, replace the `listr` renderer with a silent one so the tests
+  // don't get confusing output in them.
+  const {getRenderer} = jest.requireMock('listr/lib/renderer');
+  mocked(getRenderer).mockImplementation(() => require('listr-silent-renderer'));
+});
+
+afterEach(() => {jest.resetAllMocks(); jest.restoreAllMocks() });
+
+test('bubbles up an exception when functions directory is missing', async () => {
+  // For this test, getFirstMatchingDirectory always errors
+  mocked(fsHelpers.getFirstMatchingDirectory).mockImplementation((basePath: string, directories: Array<string>): string => {
+    throw new Error(`Could not find any of these directories "${directories.join('", "')}"`);
+  });
+
+  await expect(writeFiles([], './testing/', 'example'))
+      .rejects.toThrowError('Could not find any of these directories "functions", "src"');
+});
+
+test('bubbles up an exception when assets directory is missing', async () => {
+  // For this test, getFirstMatchingDirectory only errors on `assets` directory.
+  mocked(fsHelpers.getFirstMatchingDirectory).mockImplementation((basePath: string, directories: Array<string>): string => {
+    if (directories.includes('functions')) {
+      return path.join(basePath, directories[0]);
+    }
+
+    throw new Error(`Could not find any of these directories "${directories.join('", "')}"`);
+  });
+
+  await expect(writeFiles([], './testing/', 'example'))
+      .rejects.toThrowError('Could not find any of these directories "assets", "static"');
+});
+
+test('installation with basic functions', async () => {
+  // For this test, getFirstMatchingDirectory never errors.
+  mocked(fsHelpers.getFirstMatchingDirectory)
+    .mockImplementation((basePath: string, directories: Array<string>): string => path.join(basePath, directories[0]));
+
+  await writeFiles(
+    [
+      { name: 'hello.js',  type: 'functions',  content: 'https://example.com/hello.js' },
+      { name: '.env',  type: '.env',  content: 'https://example.com/.env' },
+    ],
+    './testing/',
+    'example'
+  );
+
+  expect(downloadFile).toHaveBeenCalledTimes(2);
+  expect(downloadFile).toHaveBeenCalledWith('https://example.com/.env', 'testing/.env');
+  expect(downloadFile).toHaveBeenCalledWith('https://example.com/hello.js', 'testing/functions/example/hello.js');
+
+  expect(mkdir).toHaveBeenCalledTimes(1);
+  expect(mkdir).toHaveBeenCalledWith('testing/functions/example', {recursive: true});
+});
+
+test('installation with functions and assets', async () => {
+  // For this test, getFirstMatchingDirectory never errors.
+  mocked(fsHelpers.getFirstMatchingDirectory)
+    .mockImplementation((basePath: string, directories: Array<string>): string => path.join(basePath, directories[0]));
+
+  await writeFiles(
+    [
+      { name: 'hello.js',  type: 'functions',  content: 'https://example.com/hello.js' },
+      { name: 'hello.wav',  type: 'assets',  content: 'https://example.com/hello.wav' },
+      { name: '.env',  type: '.env',  content: 'https://example.com/.env' },
+    ],
+    './testing/',
+    'example'
+  );
+
+  expect(downloadFile).toHaveBeenCalledTimes(3);
+  expect(downloadFile).toHaveBeenCalledWith('https://example.com/.env', 'testing/.env');
+  expect(downloadFile).toHaveBeenCalledWith('https://example.com/hello.js', 'testing/functions/example/hello.js');
+  expect(downloadFile).toHaveBeenCalledWith('https://example.com/hello.wav', 'testing/assets/example/hello.wav');
+
+  expect(mkdir).toHaveBeenCalledTimes(2);
+  expect(mkdir).toHaveBeenCalledWith('testing/functions/example', {recursive: true});
+  expect(mkdir).toHaveBeenCalledWith('testing/assets/example', {recursive: true});
+});
+
+test('installation without dot-env file causes unexpected crash', async () => {
+  // I don't believe this is the intended behavior but it's the current behavior.
+  // As such, let's create a test for it which can be removed / changed later
+  // once the behavior is fixed.
+
+  // For this test, getFirstMatchingDirectory never errors.
+  mocked(fsHelpers.getFirstMatchingDirectory)
+    .mockImplementation((basePath: string, directories: Array<string>): string => path.join(basePath, directories[0]));
+
+  const expected = new TypeError('Cannot read property \'newEnvironmentVariableKeys\' of undefined');
+
+  await expect(writeFiles([], './testing/', 'example'))
+    .rejects.toThrowError(expected);
+});
+
+test('installation with an empty dependency file', async () => {
+  // The typing of `got` is not exactly correct for this - it expects a
+  // buffer but depending on inputs `got` can actually return an object.
+  // @ts-ignore
+  mocked(got).mockImplementation(() => Promise.resolve({ body: { dependencies: {} } }));
+
+  // For this test, getFirstMatchingDirectory never errors.
+  mocked(fsHelpers.getFirstMatchingDirectory)
+    .mockImplementation((basePath: string, directories: Array<string>): string => path.join(basePath, directories[0]));
+
+  await writeFiles(
+    [
+      { name: 'package.json',  type: 'package.json',  content: 'https://example.com/package.json' },
+      { name: '.env',  type: '.env',  content: 'https://example.com/.env' },
+    ],
+    './testing/',
+    'example'
+  );
+
+  expect(downloadFile).toHaveBeenCalledTimes(1);
+  expect(downloadFile).toHaveBeenCalledWith('https://example.com/.env', 'testing/.env');
+
+  expect(got).toHaveBeenCalledTimes(1);
+  expect(got).toHaveBeenCalledWith('https://example.com/package.json', { json: true });
+
+  expect(install).not.toHaveBeenCalled();
+});
+
+test('installation with a dependency file', async () => {
+  // The typing of `got` is not exactly correct for this - it expects a
+  // buffer but depending on inputs `got` can actually return an object.
+  // @ts-ignore
+  mocked(got).mockImplementation(() => Promise.resolve({ body: { dependencies: {foo: '^1.0.0', got: '^6.9.0'} } }));
+
+  // For this test, getFirstMatchingDirectory never errors.
+  mocked(fsHelpers.getFirstMatchingDirectory)
+    .mockImplementation((basePath: string, directories: Array<string>): string => path.join(basePath, directories[0]));
+
+  await writeFiles(
+    [
+      { name: 'package.json',  type: 'package.json',  content: 'https://example.com/package.json' },
+      { name: '.env',  type: '.env',  content: 'https://example.com/.env' },
+    ],
+    './testing/',
+    'example'
+  );
+
+  expect(downloadFile).toHaveBeenCalledTimes(1);
+  expect(downloadFile).toHaveBeenCalledWith('https://example.com/.env', 'testing/.env');
+
+  expect(got).toHaveBeenCalledTimes(1);
+  expect(got).toHaveBeenCalledWith('https://example.com/package.json', { json: true });
+
+  expect(install).toHaveBeenCalledTimes(1);
+  expect(install).toHaveBeenCalledWith({foo: '^1.0.0', got: '^6.9.0'}, {cwd: './testing/'});
+});
+
+test('installation with an existing dot-env file', async () => {
+  mocked(fileExists).mockReturnValue(Promise.resolve(true));
+  mocked(readFile).mockReturnValue(Promise.resolve('# Comment\nFOO=BAR\n'));
+
+  // The typing of `got` is not exactly correct for this - it expects a
+  // buffer but depending on inputs `got` can actually return an object.
+  // @ts-ignore
+  mocked(got).mockImplementation(() => Promise.resolve({ body: 'HELLO=WORLD\n' }));
+
+  // For this test, getFirstMatchingDirectory never errors.
+  mocked(fsHelpers.getFirstMatchingDirectory)
+    .mockImplementation((basePath: string, directories: Array<string>): string => path.join(basePath, directories[0]));
+
+  await writeFiles(
+    [
+      { name: '.env',  type: '.env',  content: 'https://example.com/.env' },
+    ],
+    './testing/',
+    'example'
+  );
+
+  expect(downloadFile).toHaveBeenCalledTimes(0);
+
+  expect(writeFile).toHaveBeenCalledTimes(1);
+  expect(writeFile).toHaveBeenCalledWith(
+    'testing/.env',
+    '# Comment\n' +
+    'FOO=BAR\n' +
+    '\n\n' +
+    '# Variables for function \".env\"\n' + // This seems to be a bug but is the output.
+    '# ---\n' +
+    'HELLO=WORLD\n',
+    "utf8"
+  );
+});
+
+test('installation with overlapping function files throws errors before writing', async () => {
+  mocked(fsHelpers.getFirstMatchingDirectory)
+    .mockImplementation((basePath: string, directories: Array<string>): string => path.join(basePath, directories[0]));
+
+  mocked(fileExists).mockImplementation((p) => Promise.resolve(p == 'functions/example/hello.js'));
+
+  await expect(writeFiles(
+    [
+      { name: 'hello.js',  type: 'functions',  content: 'https://example.com/hello.js' },
+      { name: '.env',  type: '.env',  content: 'https://example.com/.env' },
+    ],
+    './',
+    'example'
+  )).rejects.toThrowError('Template with name "example" has duplicate file "hello.js" in "functions"');
+
+  expect(downloadFile).toHaveBeenCalledTimes(0);
+  expect(writeFile).toHaveBeenCalledTimes(0);
+
+});
+
+test('installation with overlapping asset files throws errors before writing', async () => {
+  mocked(fsHelpers.getFirstMatchingDirectory)
+    .mockImplementation((basePath: string, directories: Array<string>): string => path.join(basePath, directories[0]));
+
+  mocked(fileExists).mockImplementation((p) => Promise.resolve(p == 'assets/example/hello.wav'));
+
+  await expect(writeFiles(
+    [
+      { name: 'hello.js',  type: 'functions',  content: 'https://example.com/hello.js' },
+      { name: 'hello.wav',  type: 'assets',  content: 'https://example.com/hello.wav' },
+      { name: '.env',  type: '.env',  content: 'https://example.com/.env' },
+    ],
+    './',
+    'example'
+  )).rejects.toThrowError('Template with name "example" has duplicate file "hello.wav" in "assets"');
+
+  expect(downloadFile).toHaveBeenCalledTimes(0);
+  expect(writeFile).toHaveBeenCalledTimes(0);
+});

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "jest": "^24.8.0",
     "jest-express": "^1.10.1",
     "lint-staged": "^8.2.1",
+    "listr-silent-renderer": "^1.1.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.18.2",
     "rimraf": "^2.6.3",

--- a/src/templating/filesystem.ts
+++ b/src/templating/filesystem.ts
@@ -1,7 +1,7 @@
 import { fsHelpers } from '@twilio-labs/serverless-api';
 import chalk from 'chalk';
 import dotenv from 'dotenv';
-import { mkdir as oldMkdir, access as oldAccess, constants as fsConstants } from 'fs';
+import { mkdir as oldMkdir } from 'fs';
 import got from 'got';
 import Listr, { ListrTask } from 'listr';
 import path from 'path';
@@ -11,7 +11,6 @@ import { downloadFile, fileExists, readFile, writeFile } from '../utils/fs';
 import { getDebugFunction, logger } from '../utils/logger';
 import { TemplateFileInfo } from './data';
 const mkdir = promisify(oldMkdir);
-const access = promisify(oldAccess);
 
 const debug = getDebugFunction('twilio-run:templating:filesystem');
 
@@ -112,28 +111,19 @@ export async function writeFiles(
     if (file.type === 'functions') {
       let filepath = path.join(functionsTargetDir, file.name);
 
-      try {
-        await access(filepath, fsConstants.F_OK);
-      } catch (err) {
-        continue;
+      if (await fileExists(filepath)) {
+        throw new Error(
+          `Template with name "${namespace}" has duplicate file "${file.name}" in "${functionsDir}"`
+        );
       }
-
-      throw new Error(
-        `Template with name "${namespace}" has duplicate file "${file.name}" in "${functionsDir}"`
-      );
-
     } else if (file.type === 'assets') {
       let filepath = path.join(assetsTargetDir, file.name);
 
-      try {
-        await access(filepath, fsConstants.F_OK);
-      } catch (err) {
-        continue;
+      if (await fileExists(filepath)) {
+        throw new Error(
+          `Template with name "${namespace}" has duplicate file "${file.name}" in "${assetsDir}"`
+        );
       }
-
-      throw new Error(
-        `Template with name "${namespace}" has duplicate file "${file.name}" in "${assetsDir}"`
-      );
     }
   }
 

--- a/src/templating/filesystem.ts
+++ b/src/templating/filesystem.ts
@@ -1,16 +1,13 @@
 import { fsHelpers } from '@twilio-labs/serverless-api';
 import chalk from 'chalk';
 import dotenv from 'dotenv';
-import { mkdir as oldMkdir } from 'fs';
 import got from 'got';
 import Listr, { ListrTask } from 'listr';
 import path from 'path';
 import { install, InstallResult } from 'pkg-install';
-import { promisify } from 'util';
-import { downloadFile, fileExists, readFile, writeFile } from '../utils/fs';
+import { downloadFile, fileExists, readFile, writeFile, mkdir } from '../utils/fs';
 import { getDebugFunction, logger } from '../utils/logger';
 import { TemplateFileInfo } from './data';
-const mkdir = promisify(oldMkdir);
 
 const debug = getDebugFunction('twilio-run:templating:filesystem');
 

--- a/src/templating/filesystem.ts
+++ b/src/templating/filesystem.ts
@@ -6,10 +6,8 @@ import Listr, { ListrTask } from 'listr';
 import path from 'path';
 import { install, InstallResult } from 'pkg-install';
 import { downloadFile, fileExists, readFile, writeFile, mkdir } from '../utils/fs';
-import { getDebugFunction, logger } from '../utils/logger';
+import { logger } from '../utils/logger';
 import { TemplateFileInfo } from './data';
-
-const debug = getDebugFunction('twilio-run:templating:filesystem');
 
 async function writeEnvFile(
   contentUrl: string,

--- a/src/templating/filesystem.ts
+++ b/src/templating/filesystem.ts
@@ -170,5 +170,3 @@ export async function writeFiles(
     );
   }
 }
-
-export { fileExists } from '../utils/fs';

--- a/src/templating/filesystem.ts
+++ b/src/templating/filesystem.ts
@@ -1,7 +1,7 @@
 import { fsHelpers } from '@twilio-labs/serverless-api';
 import chalk from 'chalk';
 import dotenv from 'dotenv';
-import { mkdir as oldMkdir } from 'fs';
+import { mkdir as oldMkdir, access as oldAccess, constants as fsConstants } from 'fs';
 import got from 'got';
 import Listr, { ListrTask } from 'listr';
 import path from 'path';
@@ -11,6 +11,7 @@ import { downloadFile, fileExists, readFile, writeFile } from '../utils/fs';
 import { getDebugFunction, logger } from '../utils/logger';
 import { TemplateFileInfo } from './data';
 const mkdir = promisify(oldMkdir);
+const access = promisify(oldAccess);
 
 const debug = getDebugFunction('twilio-run:templating:filesystem');
 
@@ -99,25 +100,40 @@ export async function writeFiles(
 
   if (functionsTargetDir !== functionsDir) {
     if (hasFilesOfType(files, 'functions')) {
-      try {
-        await mkdir(functionsTargetDir);
-      } catch (err) {
-        debug(err);
-        throw new Error(
-          `Template with name "${namespace}" already exists in "${functionsDir}"`
-        );
-      }
+      await mkdir(functionsTargetDir, { recursive: true });
     }
 
     if (hasFilesOfType(files, 'assets')) {
+      await mkdir(assetsTargetDir, { recursive: true });
+    }
+  }
+
+  for (let file of files) {
+    if (file.type === 'functions') {
+      let filepath = path.join(functionsTargetDir, file.name);
+
       try {
-        await mkdir(assetsTargetDir);
+        await access(filepath, fsConstants.F_OK);
       } catch (err) {
-        debug(err);
-        throw new Error(
-          `Template with name "${namespace}" already exists in "${assetsDir}"`
-        );
+        continue;
       }
+
+      throw new Error(
+        `Template with name "${namespace}" has duplicate file "${file.name}" in "${functionsDir}"`
+      );
+
+    } else if (file.type === 'assets') {
+      let filepath = path.join(assetsTargetDir, file.name);
+
+      try {
+        await access(filepath, fsConstants.F_OK);
+      } catch (err) {
+        continue;
+      }
+
+      throw new Error(
+        `Template with name "${namespace}" has duplicate file "${file.name}" in "${assetsDir}"`
+      );
     }
   }
 

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -7,6 +7,7 @@ const access = promisify(fs.access);
 export const readFile = promisify(fs.readFile);
 export const writeFile = promisify(fs.writeFile);
 export const readdir = promisify(fs.readdir);
+export const mkdir = promisify(fs.mkdir);
 const stat = promisify(fs.stat);
 const open = promisify(fs.open);
 


### PR DESCRIPTION
Closes #69

this allows you to install multiple templates under the same
namepace

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
