### PR TITLE
Added .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ typings/
 # next.js build output
 .next
 
+# MacOS directory cache
+.DS_Store
+
 .vscode/settings.json
 dist/
 


### PR DESCRIPTION
<!-- Describe your Pull Request -->
## Description
Mac users face this issue a lot when they're updating their repositories locally and sometimes send the .DS_Store file which is just MacOS folder cache.
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
