### PR TITLE
feat(activate): change activate to alias, promote to command

### DIFF
--- a/src/commands/activate.ts
+++ b/src/commands/activate.ts
@@ -83,15 +83,18 @@ export const cliInfo: CliInfo = {
     },
     'build-sid': {
       type: 'string',
+      alias: 'from-build',
       describe: 'An existing Build SID to deploy to the new environment',
     },
     'source-environment': {
       type: 'string',
+      alias: 'from',
       describe:
         'SID or suffix of an existing environment you want to deploy from.',
     },
     environment: {
       type: 'string',
+      alias: 'to',
       describe: 'The environment suffix or SID to deploy to.',
       requiresArg: true,
     },
@@ -132,11 +135,19 @@ export const cliInfo: CliInfo = {
 function optionBuilder<T>(yargs: Argv<any>): Argv<ActivateCliFlags> {
   yargs = yargs
     .example(
-      '$0 activate --environment=prod --source-environment=dev  ',
+      '$0 promote --environment=prod --source-environment=dev  ',
       'Promotes the same build that is on the "dev" environment to the "prod" environment'
     )
     .example(
-      '$0 activate --environment=demo --create-environment --build-sid=ZB1234xxxxxxxxxx',
+      '$0 promote --to=prod --from=dev  ',
+      'Promotes the same build that is on the "dev" environment to the "prod" environment'
+    )
+    .example(
+      '$0 promote --environment=demo --create-environment --build-sid=ZB1234xxxxxxxxxx',
+      'Duplicates an existing build to a new environment called `demo`'
+    )
+    .example(
+      '$0 promote --to=demo --create-environment --from-build=ZB1234xxxxxxxxxx',
       'Duplicates an existing build to a new environment called `demo`'
     );
 
@@ -147,6 +158,6 @@ function optionBuilder<T>(yargs: Argv<any>): Argv<ActivateCliFlags> {
   return yargs;
 }
 
-export const command = ['activate', 'promote'];
+export const command = ['promote', 'activate'];
 export const describe = 'Promotes an existing deployment to a new environment';
 export const builder = optionBuilder;


### PR DESCRIPTION
Makes `promote` the primary command, with alias `activate`.

Adds option aliases for 'activate' / 'promote' command:

* `from` = `source-environment`
* `from-build` = `build-sid`
* `to` = `environment`

Adds appropriate examples showing usage.

resolves twilio-labs/serverless-toolkit#8

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
