### PR TITLE
feature: #90 allow users to specify a github token

### DIFF
--- a/src/templating/data.ts
+++ b/src/templating/data.ts
@@ -58,7 +58,7 @@ async function getFiles(
   templateId: string,
   directory: string
 ): Promise<TemplateFileInfo[]> {
-  const headers = await buildHeaders();
+  const headers = buildHeader();
   const response = await got(CONTENT_BASE_URL + `/${templateId}/${directory}`, {
     json: true,
     headers,
@@ -77,7 +77,7 @@ export async function getTemplateFiles(
   templateId: string
 ): Promise<TemplateFileInfo[]> {
   try {
-    const headers = await buildHeaders();
+    const headers = buildHeader();
     const response = await got(CONTENT_BASE_URL + `/${templateId}`, {
       json: true,
       headers,
@@ -137,14 +137,8 @@ export async function getTemplateFiles(
   }
 }
 
-async function buildHeaders(): Promise<OutgoingHttpHeaders> {
+function buildHeader(): OutgoingHttpHeaders {
   let githubToken = '';
-  const { localEnv } = await readLocalEnvFile({ cwd: process.cwd() });
-
-  if (localEnv.TWILIO_SERVERLESS_GITHUB_TOKEN) {
-    githubToken = localEnv.TWILIO_SERVERLESS_GITHUB_TOKEN;
-  }
-
   if (process.env.TWILIO_SERVERLESS_GITHUB_TOKEN) {
     githubToken = process.env.TWILIO_SERVERLESS_GITHUB_TOKEN;
   }

--- a/src/templating/data.ts
+++ b/src/templating/data.ts
@@ -1,5 +1,6 @@
 import got from 'got';
 import { getDebugFunction } from '../utils/logger';
+import { stripIndent } from 'common-tags';
 
 const debug = getDebugFunction('twilio-run:new:template-data');
 
@@ -104,10 +105,27 @@ export async function getTemplateFiles(
     debug(err.message);
 
     if (err.response) {
-      const bodyMessage = err.response.body as GitHubError;
-      throw new Error(
-        bodyMessage ? `${err.message}\n${bodyMessage.message}` : err.message
-      );
+      if (err.response.statusCode === 403) {
+        throw new Error(
+          stripIndent`
+          We are sorry but we failed fetching the requested template from GitHub because your IP address has been rate limited. Please try the following to resolve the issue:
+
+          - Change your WiFi or make sure you are not connected to a VPN that might cause the rate limiting
+
+
+          If the issue persists you can try one of the two options:
+
+          - Get a GitHub developer token following https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line (no permissions needed) and add it as TWILIO_SERVERLESS_GITHUB_TOKEN to your environment variables
+
+          - Wait for a few minutes up to an hour and try again.
+          `
+        );
+      } else {
+        const bodyMessage = err.response.body as GitHubError;
+        throw new Error(
+          bodyMessage ? `${err.message}\n${bodyMessage.message}` : err.message
+        );
+      }
     }
 
     throw new Error('Invalid template');

--- a/src/types/generic.ts
+++ b/src/types/generic.ts
@@ -3,5 +3,4 @@ import { EnvironmentVariables } from '@twilio-labs/serverless-api';
 export type EnvironmentVariablesWithAuth = EnvironmentVariables & {
   ACCOUNT_SID?: string;
   AUTH_TOKEN?: string;
-  TWILIO_SERVERLESS_GITHUB_TOKEN?: string;
 };

--- a/src/types/generic.ts
+++ b/src/types/generic.ts
@@ -3,4 +3,5 @@ import { EnvironmentVariables } from '@twilio-labs/serverless-api';
 export type EnvironmentVariablesWithAuth = EnvironmentVariables & {
   ACCOUNT_SID?: string;
   AUTH_TOKEN?: string;
+  TWILIO_SERVERLESS_GITHUB_TOKEN?: string;
 };


### PR DESCRIPTION
Adds #90 functionality by allowing the user to circumvent rate limiting with an auth token specified in their environment.

First time contributing  to a CLI, so looking for suggestions on improvement. 🙂

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
