### PR TITLE
feat(server): expose function path to context

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -6,10 +6,10 @@ newIssueWelcomeComment: |
 firstPRMergeComment: >
   Congratulations on your first contribution to the Serverless Toolkit!
 
-  We'd love to say thank you and send you some swag. If you are interested please fill out this form at https://twil.io/hacktoberfest-swag
-
   If you are on the look out for more ways to contribute to open-source, 
   check out a list of some of our repositories at https://github.com/twilio/opensource.
+
+  If you want to stay up-to-date with Twilio's OSS activities, subscribe here: https://twil.io/oss-updates
 
   And if you love Twilio as much as we do, make sure to check out our 
   [Twilio Champions program](https://www.twilio.com/champions)!

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ typings/
 dist/
 
 *.tsbuildinfo
+.twilio-functions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ npm install
 
 1. Perform changes
 2. Make sure tests pass by running `npm test`
-3. Run `git commit`  to kick off validation and enter your commit message. We are using [conventional commits](https://www.conventionalcommits.org/en/) for this project. When you run `git commit` it will trigger [`commitizen`](https://npm.im/commitizen) to assist you with your commit message.
+3. Run `git commit`  to kick off validation and enter your commit message. We are using [conventional commits](https://www.conventionalcommits.org/en/) for this project. When you run `npm run cm` it will trigger [`commitizen`](https://npm.im/commitizen) to assist you with your commit message.
 4. Submit a Pull Request 
 
 **Working on your first Pull Request?** You can learn how from this *free* series [How to Contribute to an Open Source Project on GitHub](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github) 

--- a/__tests__/runtime/route.test.ts
+++ b/__tests__/runtime/route.test.ts
@@ -191,7 +191,7 @@ describe('constructContext function', () => {
     expect(typeof context.getTwilioClient).toBe('function');
   });
 
-  test('overrides existing PATH', () => {
+  test('does not override existing PATH values', () => {
     const env: EnvironmentVariablesWithAuth = {
       ACCOUNT_SID: 'ACxxxxxxxxxxx',
       AUTH_TOKEN: 'xyz',
@@ -203,11 +203,22 @@ describe('constructContext function', () => {
       env,
     } as StartCliConfig;
     const context = constructContext(config, '/test2');
-    expect(context.DOMAIN_NAME).toBe('localhost:8000');
-    expect(context.PATH).toBe('/test2');
-    expect(context.ACCOUNT_SID).toBe('ACxxxxxxxxxxx');
-    expect(context.AUTH_TOKEN).toBe('xyz');
-    expect(typeof context.getTwilioClient).toBe('function');
+    expect(context.PATH).toBe('/usr/bin:/bin');
+  });
+
+  test('does not override existing DOMAIN_NAME values', () => {
+    const env: EnvironmentVariablesWithAuth = {
+      ACCOUNT_SID: 'ACxxxxxxxxxxx',
+      AUTH_TOKEN: 'xyz',
+      DOMAIN_NAME: 'hello.world',
+    };
+
+    const config = {
+      url: 'http://localhost:8000',
+      env,
+    } as StartCliConfig;
+    const context = constructContext(config, '/test2');
+    expect(context.DOMAIN_NAME).toBe('hello.world');
   });
 
   test('getTwilioClient calls twilio constructor', () => {

--- a/examples/basic/functions/hello.js
+++ b/examples/basic/functions/hello.js
@@ -3,5 +3,6 @@
 exports.handler = function(context, event, callback) {
   let twiml = new Twilio.twiml.MessagingResponse();
   twiml.message('Hello World');
+  console.log(context);
   callback(null, twiml);
 };

--- a/examples/basic/functions/hello.js
+++ b/examples/basic/functions/hello.js
@@ -3,6 +3,5 @@
 exports.handler = function(context, event, callback) {
   let twiml = new Twilio.twiml.MessagingResponse();
   twiml.message('Hello World');
-  console.log(context);
   callback(null, twiml);
 };

--- a/package.json
+++ b/package.json
@@ -119,7 +119,6 @@
   "husky": {
     "hooks": {
       "pre-commit": "run-s lint-staged test",
-      "prepare-commit-msg": "exec < /dev/tty && git-cz --hook",
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
       "post-checkout": "reset-dependencies",
       "post-merge": "reset-dependencies"

--- a/package.json
+++ b/package.json
@@ -119,9 +119,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "run-s lint-staged test",
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "post-checkout": "reset-dependencies",
-      "post-merge": "reset-dependencies"
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   },
   "lint-staged": {

--- a/src/runtime/route.ts
+++ b/src/runtime/route.ts
@@ -46,7 +46,7 @@ export function constructContext<T extends {} = {}>(
   }
   const DOMAIN_NAME = url.replace(/^https?:\/\//, '');
   const PATH = functionPath;
-  return { ...env, DOMAIN_NAME, PATH, getTwilioClient };
+  return { PATH, DOMAIN_NAME, ...env, getTwilioClient };
 }
 
 export function constructGlobalScope(config: StartCliConfig): void {

--- a/src/runtime/route.ts
+++ b/src/runtime/route.ts
@@ -25,12 +25,14 @@ export function constructEvent<T extends {} = {}>(req: ExpressRequest): T {
   return { ...req.query, ...req.body };
 }
 
-export function constructContext<T extends {} = {}>({
-  url,
-  env,
-}: StartCliConfig): Context<{
+export function constructContext<T extends {} = {}>(
+  { url, env }: StartCliConfig,
+  functionPath: string
+): Context<{
   ACCOUNT_SID?: string;
   AUTH_TOKEN?: string;
+  DOMAIN_NAME: string;
+  PATH: string;
   [key: string]: string | undefined | Function;
 }> {
   function getTwilioClient(): twilio.Twilio {
@@ -43,7 +45,8 @@ export function constructContext<T extends {} = {}>({
     return twilio(env.ACCOUNT_SID, env.AUTH_TOKEN);
   }
   const DOMAIN_NAME = url.replace(/^https?:\/\//, '');
-  return { ...env, DOMAIN_NAME, getTwilioClient };
+  const PATH = functionPath;
+  return { ...env, DOMAIN_NAME, PATH, getTwilioClient };
 }
 
 export function constructGlobalScope(config: StartCliConfig): void {
@@ -129,7 +132,7 @@ export function functionToRoute(
   ) {
     const event = constructEvent(req);
     debug('Event for %s: %o', req.path, event);
-    const context = constructContext(config);
+    const context = constructContext(config, req.path);
     debug('Context for %s: %p', req.path, context);
     let run_timings: {
       start: [number, number];


### PR DESCRIPTION
<!-- Describe your Pull Request -->

This exposes the current function path as the PATH property on the context. This catches up with the
release of that variable in the Twilio Functions environment as introduced in
twilio.com/changelog/twilio-functions-context-path

I marked this as a breaking change because if someone used `PATH` as an env variable before this will not work anymore. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
