### PR TITLE
fix(server): update request body size

### DIFF
--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -14,10 +14,11 @@ import { getDebugFunction } from '../utils/logger';
 import { createLogger } from './internal/request-logger';
 import { setRoutes } from './internal/route-cache';
 import { getFunctionsAndAssets } from './internal/runtime-paths';
-import { functionToRoute, constructGlobalScope } from './route';
+import { constructGlobalScope, functionToRoute } from './route';
 
 const debug = getDebugFunction('twilio-run:server');
 const DEFAULT_PORT = process.env.PORT || 3000;
+const DEFAULT_BODY_SIZE_LAMBDA = '6mb';
 
 function requireUncached(module: string): any {
   delete require.cache[require.resolve(module)];
@@ -50,8 +51,10 @@ export async function createServer(
 
   const app = express();
   app.use(userAgentMiddleware.express());
-  app.use(bodyParser.urlencoded({ extended: false }));
-  app.use(bodyParser.json());
+  app.use(
+    bodyParser.urlencoded({ extended: false, limit: DEFAULT_BODY_SIZE_LAMBDA })
+  );
+  app.use(bodyParser.json({ limit: DEFAULT_BODY_SIZE_LAMBDA }));
   app.get('/favicon.ico', (req, res) => {
     res.redirect(
       'https://www.twilio.com/marketing/bundles/marketing/img/favicons/favicon.ico'


### PR DESCRIPTION
This changes the limit for the request body size from 100kb to 6mb which is the default for
Lambda/Twilio Functions

fix #98

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
