### PR TITLE
fix: #111 change pinned node version to 10.x

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,8 @@ This project contains the CLI aspects of deploying Twilio Serverless as well as 
 
 ## Requirements
 
-Make sure you have Node.js 10.17 or newer installed. Due to compatibility with Twilio
-Functions this project has to support at least Node.js 10.17.
+Make sure you have Node.js 10 or newer installed. Due to compatibility with Twilio
+Functions this project has to support at least Node.js 10.0.0.
 
 ## Setup
 

--- a/src/checks/nodejs-version.ts
+++ b/src/checks/nodejs-version.ts
@@ -1,7 +1,7 @@
 import { stripIndent } from 'common-tags';
 import { logger } from '../utils/logger';
 
-const SERVERLESS_NODE_JS_VERSION = '10.17';
+const SERVERLESS_NODE_JS_VERSION = '10.';
 
 export function printVersionWarning(
   nodeVersion: string,
@@ -9,7 +9,7 @@ export function printVersionWarning(
 ): void {
   const title = 'Different Node.js Version Found';
   const msg = stripIndent`
-      You are currently running Node.js ${nodeVersion} on this local machine. The production environment for Twilio Serverless is currently on ${expectedVersion}.
+      You are currently running Node.js ${nodeVersion} on this local machine. The production environment for Twilio Serverless currently supports versions ${expectedVersion}x.
 
       When you deploy to Twilio Serverless, you may encounter differences between local development and production.
 


### PR DESCRIPTION
Currently, we check if the node version is 10.17. Twilio Functions cloud no longer checks minor
versions so we only need to check for 10.x

fix #111

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
