### PR TITLE
feat(start): handle EADDRINUSE by asking for another port number

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -23,6 +23,18 @@ function randomPort() {
   return Math.floor(Math.random() * (65535 - 1025) + 1025);
 }
 
+function validatePortNumber(input: string) {
+  const newPortNumber = parseInt(input, 10);
+  if (
+    !Number.isNaN(newPortNumber) &&
+    newPortNumber <= 65535 &&
+    newPortNumber > 1024
+  ) {
+    return true;
+  }
+  return 'Please enter a port number between 1025 and 65535.';
+}
+
 export async function handler(
   argv: StartCliFlags,
   externalCliOptions?: ExternalCliOptions
@@ -71,17 +83,7 @@ export async function handler(
               default: randomPort(),
               name: 'newPortNumber',
               message: `Port ${config.port} is already in use. Choose a new port number:`,
-              validate: input => {
-                const newPortNumber = parseInt(input, 10);
-                if (
-                  !Number.isNaN(newPortNumber) &&
-                  newPortNumber <= 65535 &&
-                  newPortNumber > 0
-                ) {
-                  return true;
-                }
-                return 'Please enter a port number between 0 and 65535.';
-              },
+              validate: validatePortNumber,
             },
           ]);
           attempts += 1;

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -17,6 +17,11 @@ type ServerError = Error & {
   code: string;
 };
 
+function randomPort() {
+  // Returns a random port number higher than 1024 and lower than 65536.
+  return Math.floor(Math.random() * (65535 - 1025) + 1025);
+}
+
 export async function handler(
   argv: StartCliFlags,
   externalCliOptions?: ExternalCliOptions
@@ -56,7 +61,7 @@ export async function handler(
         const answers = await inquirer.prompt([
           {
             type: 'input',
-            default: config.port + 1,
+            default: randomPort(),
             name: 'newPortNumber',
             message: `Port ${config.port} is already in use. Choose a new port number:`,
             validate: input => {


### PR DESCRIPTION
If the server errors with `EADDRINUSE` then we ask for a new port number with the default of the existing port number + 1.

Fixes #97.



**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
