### PR TITLE
fix(templating): catch errors in command, not before

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -5,7 +5,7 @@ import { Merge } from 'type-fest';
 import { Arguments, Argv } from 'yargs';
 import checkProjectStructure from '../checks/project-structure';
 import { downloadTemplate, fetchListOfTemplates } from '../templating/actions';
-import { setLogLevelByName } from '../utils/logger';
+import { setLogLevelByName, logger } from '../utils/logger';
 import { baseCliOptions, BaseFlags, ExternalCliOptions } from './shared';
 import { CliInfo } from './types';
 import { getFullCommand } from './utils';
@@ -112,7 +112,11 @@ export async function handler(
 
   const sanitizedNamespace = flags.namespace.replace(/\.js$/, '');
 
-  downloadTemplate(flags.template, sanitizedNamespace, targetDirectory);
+  try {
+    await downloadTemplate(flags.template, sanitizedNamespace, targetDirectory);
+  } catch (error) {
+    logger.error(error.message, error.name);
+  }
 }
 
 export const cliInfo: CliInfo = {

--- a/src/templating/actions.ts
+++ b/src/templating/actions.ts
@@ -9,22 +9,19 @@ export async function downloadTemplate(
   namespace: string,
   targetDirectory: string
 ): Promise<void> {
-  try {
-    const files = await getTemplateFiles(templateName);
-    await writeFiles(files, targetDirectory, namespace, templateName);
-    logger.info(
-      chalk`{green SUCCESS} Downloaded new template into the "${namespace}" subdirectories.`
-    );
-    logger.info(
-      `Check ${path.join(
-        'readmes',
-        namespace,
-        `${templateName}.md`
-      )} for template instructions.`
-    );
-  } catch (err) {
-    logger.error(err.message, err.name);
-  }
+  const files = await getTemplateFiles(templateName);
+
+  await writeFiles(files, targetDirectory, namespace, templateName);
+  logger.info(
+    chalk`{green SUCCESS} Downloaded new template into the "${namespace}" subdirectories.`
+  );
+  logger.info(
+    `Check ${path.join(
+      'readmes',
+      namespace,
+      `${templateName}.md`
+    )} for template instructions.`
+  );
 }
 
 export { fetchListOfTemplates } from './data';


### PR DESCRIPTION
`create-twilio-function` uses `downloadTemplate` from `src/templating/actions` and that would previously throw an error for a missing/nonexistant template, but it changed to catch it. Downstream functions shouldn't catch and log errors because the function consumers won't know if something went wrong.

Fixes [create-twilio-function#51](https://github.com/twilio-labs/create-twilio-function/issues/51).

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
