### PR TITLE
feat(flags): expose region/edge flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "author": "Dominik Kundel <dkundel@twilio.com>",
   "license": "MIT",
   "dependencies": {
-    "@twilio-labs/serverless-api": "^2.0.1",
+    "@twilio-labs/serverless-api": "^2.1.0",
     "@twilio-labs/serverless-runtime-types": "^1.1.7",
     "@types/express": "^4.17.0",
     "@types/inquirer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "author": "Dominik Kundel <dkundel@twilio.com>",
   "license": "MIT",
   "dependencies": {
-    "@twilio-labs/serverless-api": "^2.1.0",
+    "@twilio-labs/serverless-api": "^3.0.0",
     "@twilio-labs/serverless-runtime-types": "^1.1.7",
     "@types/express": "^4.17.0",
     "@types/inquirer": "^6.0.3",

--- a/src/commands/activate.ts
+++ b/src/commands/activate.ts
@@ -14,7 +14,11 @@ import {
   logger,
   setLogLevelByName,
 } from '../utils/logger';
-import { ExternalCliOptions, sharedCliOptions } from './shared';
+import {
+  ExternalCliOptions,
+  sharedApiRelatedCliOptions,
+  sharedCliOptions,
+} from './shared';
 import { CliInfo } from './types';
 
 const debug = getDebugFunction('twilio-run:activate');
@@ -83,6 +87,7 @@ export async function handler(
 export const cliInfo: CliInfo = {
   options: {
     ...sharedCliOptions,
+    ...sharedApiRelatedCliOptions,
     'service-sid': {
       type: 'string',
       describe: 'SID of the Twilio Serverless Service to deploy to',
@@ -107,17 +112,6 @@ export const cliInfo: CliInfo = {
       type: 'boolean',
       describe:
         'Promote build to the production environment (no domain suffix). Overrides environment flag',
-    },
-    'account-sid': {
-      type: 'string',
-      alias: 'u',
-      describe:
-        'A specific account SID to be used for deployment. Uses fields in .env otherwise',
-    },
-    'auth-token': {
-      type: 'string',
-      describe:
-        'Use a specific auth token for deployment. Uses fields from .env otherwise',
     },
     'create-environment': {
       type: 'boolean',

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -18,7 +18,11 @@ import {
   logger,
   setLogLevelByName,
 } from '../utils/logger';
-import { ExternalCliOptions, sharedCliOptions } from './shared';
+import {
+  ExternalCliOptions,
+  sharedApiRelatedCliOptions,
+  sharedCliOptions,
+} from './shared';
 import { CliInfo } from './types';
 import { constructCommandName, getFullCommand } from './utils';
 
@@ -125,6 +129,7 @@ export async function handler(
 export const cliInfo: CliInfo = {
   options: {
     ...sharedCliOptions,
+    ...sharedApiRelatedCliOptions,
     cwd: {
       type: 'string',
       describe: 'Sets the directory from which to deploy',
@@ -162,17 +167,6 @@ export const cliInfo: CliInfo = {
       hidden: true,
       describe:
         'DEPRECATED: Overrides the name of the project. Default: the name field in your package.json',
-    },
-    'account-sid': {
-      type: 'string',
-      alias: 'u',
-      describe:
-        'A specific account SID to be used for deployment. Uses fields in .env otherwise',
-    },
-    'auth-token': {
-      type: 'string',
-      describe:
-        'Use a specific auth token for deployment. Uses fields from .env otherwise',
     },
     env: {
       type: 'string',

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -10,7 +10,11 @@ import {
   logger,
   setLogLevelByName,
 } from '../utils/logger';
-import { ExternalCliOptions, sharedCliOptions } from './shared';
+import {
+  ExternalCliOptions,
+  sharedApiRelatedCliOptions,
+  sharedCliOptions,
+} from './shared';
 import { CliInfo } from './types';
 import { getFullCommand } from './utils';
 
@@ -74,6 +78,7 @@ export const cliInfo: CliInfo = {
   },
   options: {
     ...sharedCliOptions,
+    ...sharedApiRelatedCliOptions,
     'service-name': {
       type: 'string',
       alias: 'n',
@@ -107,17 +112,6 @@ export const cliInfo: CliInfo = {
       type: 'string',
       describe: 'The environment to list variables for',
       default: 'dev',
-    },
-    'account-sid': {
-      type: 'string',
-      alias: 'u',
-      describe:
-        'A specific account SID to be used for deployment. Uses fields in .env otherwise',
-    },
-    'auth-token': {
-      type: 'string',
-      describe:
-        'Use a specific auth token for deployment. Uses fields from .env otherwise',
     },
     'service-sid': {
       type: 'string',

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -13,7 +13,11 @@ import {
   logger,
   setLogLevelByName,
 } from '../utils/logger';
-import { ExternalCliOptions, sharedCliOptions } from './shared';
+import {
+  ExternalCliOptions,
+  sharedApiRelatedCliOptions,
+  sharedCliOptions,
+} from './shared';
 import { CliInfo } from './types';
 import { getFullCommand } from './utils';
 
@@ -78,6 +82,7 @@ export async function handler(
 export const cliInfo: CliInfo = {
   options: {
     ...sharedCliOptions,
+    ...sharedApiRelatedCliOptions,
     'service-sid': {
       type: 'string',
       describe: 'Specific Serverless Service SID to retrieve logs for',
@@ -101,17 +106,6 @@ export const cliInfo: CliInfo = {
       default: '',
       describe: 'Output the log in a different format',
       choices: ['', 'json'],
-    },
-    'account-sid': {
-      type: 'string',
-      alias: 'u',
-      describe:
-        'A specific account SID to be used for deployment. Uses fields in .env otherwise',
-    },
-    'auth-token': {
-      type: 'string',
-      describe:
-        'Use a specific auth token for deployment. Uses fields from .env otherwise',
     },
     env: {
       type: 'string',

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -10,10 +10,12 @@ export type SharedFlags = BaseFlags & {
   cwd?: string;
 };
 
-export type SharedFlagsWithCrdentials = SharedFlags & {
+export type SharedFlagsWithCredentials = SharedFlags & {
   accountSid?: string;
   authToken?: string;
   env?: string;
+  region?: string;
+  edge?: string;
 };
 
 export type ExternalCliOptions = {
@@ -33,6 +35,30 @@ export const baseCliOptions: { [key: string]: Options } = {
     alias: 'l',
     describe: 'Level of logging messages.',
     choices: Object.keys(LoggingLevel),
+  },
+};
+
+export const sharedApiRelatedCliOptions: { [key: string]: Options } = {
+  region: {
+    type: 'string',
+    hidden: true,
+    describe: 'Twilio API Region',
+  },
+  edge: {
+    type: 'string',
+    hidden: true,
+    describe: 'Twilio API Region',
+  },
+  'account-sid': {
+    type: 'string',
+    alias: 'u',
+    describe:
+      'A specific account SID to be used for deployment. Uses fields in .env otherwise',
+  },
+  'auth-token': {
+    type: 'string',
+    describe:
+      'Use a specific auth token for deployment. Uses fields from .env otherwise',
   },
 };
 

--- a/src/config/activate.ts
+++ b/src/config/activate.ts
@@ -5,7 +5,7 @@ import checkForValidServiceSid from '../checks/check-service-sid';
 import { cliInfo } from '../commands/activate';
 import {
   ExternalCliOptions,
-  SharedFlagsWithCrdentials,
+  SharedFlagsWithCredentials,
 } from '../commands/shared';
 import { getFullCommand } from '../commands/utils';
 import { readSpecializedConfig } from './global';
@@ -19,7 +19,7 @@ type ActivateConfig = ApiActivateConfig & {
 };
 
 export type ActivateCliFlags = Arguments<
-  SharedFlagsWithCrdentials & {
+  SharedFlagsWithCredentials & {
     cwd?: string;
     serviceSid?: string;
     buildSid?: string;
@@ -64,6 +64,8 @@ export async function getConfigFromFlags(
 
   const command = getFullCommand(flags);
   const serviceSid = checkForValidServiceSid(command, flags.serviceSid);
+  const region = flags.region;
+  const edge = flags.edge;
 
   return {
     cwd,
@@ -75,5 +77,7 @@ export async function getConfigFromFlags(
     buildSid: flags.buildSid,
     targetEnvironment: flags.environment,
     sourceEnvironment: flags.sourceEnvironment,
+    region,
+    edge,
   };
 }

--- a/src/config/deploy.ts
+++ b/src/config/deploy.ts
@@ -4,7 +4,7 @@ import { Arguments } from 'yargs';
 import { cliInfo } from '../commands/deploy';
 import {
   ExternalCliOptions,
-  SharedFlagsWithCrdentials,
+  SharedFlagsWithCredentials,
 } from '../commands/shared';
 import { deprecateFunctionsEnv } from '../commands/utils';
 import { getFunctionServiceSid } from '../serverless-api/utils';
@@ -18,7 +18,7 @@ import {
 import { mergeFlagsAndConfig } from './utils/mergeFlagsAndConfig';
 
 export type DeployCliFlags = Arguments<
-  SharedFlagsWithCrdentials & {
+  SharedFlagsWithCredentials & {
     serviceSid?: string;
     functionsEnv?: string;
     environment: string;
@@ -105,6 +105,9 @@ export async function getConfigFromFlags(
     );
   }
 
+  const region = flags.region;
+  const edge = flags.edge;
+
   return {
     cwd,
     envPath,
@@ -121,5 +124,7 @@ export async function getConfigFromFlags(
     assetsFolderName: flags.assetsFolder,
     noAssets: !flags.assets,
     noFunctions: !flags.functions,
+    region,
+    edge,
   };
 }

--- a/src/config/list.ts
+++ b/src/config/list.ts
@@ -7,7 +7,7 @@ import { Arguments } from 'yargs';
 import { cliInfo } from '../commands/list';
 import {
   ExternalCliOptions,
-  SharedFlagsWithCrdentials,
+  SharedFlagsWithCredentials,
 } from '../commands/shared';
 import { getFunctionServiceSid } from '../serverless-api/utils';
 import { readSpecializedConfig } from './global';
@@ -21,7 +21,7 @@ export type ListConfig = ApiListConfig & {
 };
 
 export type ListCliFlags = Arguments<
-  SharedFlagsWithCrdentials & {
+  SharedFlagsWithCredentials & {
     types: string;
     projectName?: string;
     serviceName?: string;
@@ -67,6 +67,8 @@ export async function getConfigFromFlags(
   let serviceName = await getServiceNameFromFlags(flags);
 
   const types = flags.types.split(',').map(trim) as ListOptions[];
+  const region = flags.region;
+  const edge = flags.edge;
 
   return {
     cwd,
@@ -80,5 +82,7 @@ export async function getConfigFromFlags(
       : undefined,
     extendedOutput: flags.extendedOutput,
     types,
+    region,
+    edge,
   };
 }

--- a/src/config/logs.ts
+++ b/src/config/logs.ts
@@ -1,27 +1,31 @@
-import { LogsConfig as ApiLogsConfig } from '@twilio-labs/serverless-api';
+import {
+  ClientConfig,
+  LogsConfig as ApiLogsConfig,
+} from '@twilio-labs/serverless-api';
 import path from 'path';
 import { Arguments } from 'yargs';
 import checkForValidServiceSid from '../checks/check-service-sid';
 import { cliInfo } from '../commands/logs';
 import {
   ExternalCliOptions,
-  SharedFlagsWithCrdentials,
+  SharedFlagsWithCredentials,
 } from '../commands/shared';
 import { getFullCommand } from '../commands/utils';
 import { readSpecializedConfig } from './global';
 import { getCredentialsFromFlags } from './utils';
 import { mergeFlagsAndConfig } from './utils/mergeFlagsAndConfig';
 
-export type LogsConfig = ApiLogsConfig & {
-  cwd: string;
-  accountSid: string;
-  authToken: string;
-  properties?: string[];
-  outputFormat?: string;
-};
+export type LogsConfig = ClientConfig &
+  ApiLogsConfig & {
+    cwd: string;
+    accountSid: string;
+    authToken: string;
+    properties?: string[];
+    outputFormat?: string;
+  };
 
 export type LogsCliFlags = Arguments<
-  SharedFlagsWithCrdentials & {
+  SharedFlagsWithCredentials & {
     cwd?: string;
     environment?: string;
     serviceSid?: string;
@@ -61,6 +65,8 @@ export async function getConfigFromFlags(
   const command = getFullCommand(flags);
   const serviceSid = checkForValidServiceSid(command, flags.serviceSid);
   const outputFormat = flags.outputFormat || externalCliOptions?.outputFormat;
+  const region = flags.region;
+  const edge = flags.edge;
 
   return {
     cwd,
@@ -71,5 +77,7 @@ export async function getConfigFromFlags(
     outputFormat,
     filterByFunction: flags.functionSid,
     tail: flags.tail,
+    region,
+    edge,
   };
 }

--- a/src/config/utils/credentials.ts
+++ b/src/config/utils/credentials.ts
@@ -1,6 +1,6 @@
 import {
   ExternalCliOptions,
-  SharedFlagsWithCrdentials,
+  SharedFlagsWithCredentials,
 } from '../../commands/shared';
 import { getDebugFunction } from '../../utils/logger';
 import { readLocalEnvFile } from './env';
@@ -24,7 +24,7 @@ export type Credentials = {
  * @param externalCliOptions Any external information for example passed by the Twilio CLI
  */
 export async function getCredentialsFromFlags<
-  T extends SharedFlagsWithCrdentials
+  T extends SharedFlagsWithCredentials
 >(flags: T, externalCliOptions?: ExternalCliOptions): Promise<Credentials> {
   // default Twilio CLI credentials (4) or empty string (5)
   let accountSid =


### PR DESCRIPTION
This exposes the new config values for region and edge.

re twilio-labs/serverless-toolkit#10

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
