### PR TITLE
feat(runtime): add CORS headers to OPTIONS requests to assets

### DIFF
--- a/__tests__/runtime/__snapshots__/integration.test.ts.snap
+++ b/__tests__/runtime/__snapshots__/integration.test.ts.snap
@@ -8,7 +8,6 @@ Object {
     "cache-control": "public, max-age=0",
     "connection": "close",
     "content-type": "application/javascript; charset=UTF-8",
-    "last-modified": "Tue, 09 Jun 2020 01:11:06 GMT",
     "x-powered-by": "Express",
   },
   "statusCode": 200,

--- a/__tests__/runtime/__snapshots__/integration.test.ts.snap
+++ b/__tests__/runtime/__snapshots__/integration.test.ts.snap
@@ -1,6 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Function integration tests basic-twiml.js should match snapshot 1`] = `
+exports[`with an express app Assets integration tests hello.js should match snapshot 1`] = `
+Object {
+  "body": Object {},
+  "headers": Object {
+    "accept-ranges": "bytes",
+    "cache-control": "public, max-age=0",
+    "connection": "close",
+    "content-type": "application/javascript; charset=UTF-8",
+    "last-modified": "Tue, 09 Jun 2020 01:11:06 GMT",
+    "x-powered-by": "Express",
+  },
+  "statusCode": 200,
+  "text": "alert('Hello world!');
+",
+  "type": "application/javascript",
+}
+`;
+
+exports[`with an express app Function integration tests basic-twiml.js should match snapshot 1`] = `
 Object {
   "body": Object {},
   "headers": Object {

--- a/__tests__/runtime/integration.test.ts
+++ b/__tests__/runtime/integration.test.ts
@@ -36,6 +36,7 @@ type InternalResponse = request.Response & {
 function responseToSnapshotJson(response: InternalResponse) {
   let { statusCode, type, body, text, headers } = response;
   delete headers['date'];
+  delete headers['last-modified'];
 
   if (text && text.startsWith('Error')) {
     // stack traces are different in every environment

--- a/__tests__/runtime/integration.test.ts
+++ b/__tests__/runtime/integration.test.ts
@@ -88,7 +88,7 @@ describe('with an express app', () => {
         expect(result).toMatchSnapshot();
       });
 
-      test(`OPTIONS request to ${testAsset.name} should return CORS headers`, async () => {
+      test(`OPTIONS request to ${testAsset.name} should return CORS headers and no body`, async () => {
         const response = (await request(app).options(
           testAsset.url
         )) as InternalResponse;
@@ -106,6 +106,7 @@ describe('with an express app', () => {
         expect(response.headers['access-control-allow-credentials']).toEqual(
           'true'
         );
+        expect(response.text).toEqual('');
       });
 
       test(`GET request to ${testAsset.name} should not return CORS headers`, async () => {

--- a/fixtures/assets/hello.js
+++ b/fixtures/assets/hello.js
@@ -1,0 +1,1 @@
+alert('Hello world!');

--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -177,18 +177,18 @@ export async function createServer(
         if (routeInfo.filePath) {
           if (routeInfo.access === 'private') {
             res.status(403).send('This asset has been marked as private');
+          } else if (req.method === 'OPTIONS') {
+            res.set({
+              'access-control-allow-origin': '*',
+              'access-control-allow-headers':
+                'Accept, Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since',
+              'access-control-allow-methods': 'GET, POST, OPTIONS',
+              'access-control-expose-headers': 'ETag',
+              'access-control-max-age': '86400',
+              'access-control-allow-credentials': true,
+            });
+            res.status(200).end();
           } else {
-            if (req.method === 'OPTIONS') {
-              res.set({
-                'access-control-allow-origin': '*',
-                'access-control-allow-headers':
-                  'Accept, Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since',
-                'access-control-allow-methods': 'GET, POST, OPTIONS',
-                'access-control-expose-headers': 'ETag',
-                'access-control-max-age': '86400',
-                'access-control-allow-credentials': true,
-              });
-            }
             res.sendFile(routeInfo.filePath);
           }
         } else {

--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -178,6 +178,17 @@ export async function createServer(
           if (routeInfo.access === 'private') {
             res.status(403).send('This asset has been marked as private');
           } else {
+            if (req.method === 'OPTIONS') {
+              res.set({
+                'access-control-allow-origin': '*',
+                'access-control-allow-headers':
+                  'Accept, Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since',
+                'access-control-allow-methods': 'GET, POST, OPTIONS',
+                'access-control-expose-headers': 'ETag',
+                'access-control-max-age': '86400',
+                'access-control-allow-credentials': true,
+              });
+            }
             res.sendFile(routeInfo.filePath);
           }
         } else {


### PR DESCRIPTION
Fixes #107. 

I checked and when you make an OPTIONS request to an asset you get these CORS headers:

```
access-control-allow-origin: *
access-control-allow-headers: Accept, Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since
access-control-allow-methods: GET, POST, OPTIONS
access-control-expose-headers: ETag
access-control-max-age: 86400
access-control-allow-credentials: true
```

But you don't get those headers for other requests.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
