### PR TITLE
fix(activate): prepare and pass env vars to serverless-api activateBuild

### DIFF
--- a/__tests__/config/utils/env.test.ts
+++ b/__tests__/config/utils/env.test.ts
@@ -1,0 +1,27 @@
+import { filterEnvVariablesForDeploy } from '../../../src/config/utils/env';
+import { EnvironmentVariablesWithAuth } from '../../../src/types/generic';
+
+describe('filterEnvVariablesForDeploy', () => {
+  const testVars: EnvironmentVariablesWithAuth = {
+    ACCOUNT_SID: 'ACCOUNT_SID',
+    AUTH_TOKEN: 'AUTH_TOKEN',
+    empty: '',
+    hello: 'world',
+  };
+
+  it('deletes ACCOUNT_SID and AUTH_TOKEN', () => {
+    const deployVars = filterEnvVariablesForDeploy(testVars);
+    expect(deployVars['ACCOUNT_SID']).toBeUndefined();
+    expect(deployVars['AUTH_TOKEN']).toBeUndefined();
+  });
+
+  it('deletes empty env vars', () => {
+    const deployVars = filterEnvVariablesForDeploy(testVars);
+    expect(deployVars['empty']).toBeUndefined();
+  });
+
+  it('leaves other variables as they were', () => {
+    const deployVars = filterEnvVariablesForDeploy(testVars);
+    expect(deployVars['hello']).toEqual('world');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "author": "Dominik Kundel <dkundel@twilio.com>",
   "license": "MIT",
   "dependencies": {
-    "@twilio-labs/serverless-api": "^3.0.0",
+    "@twilio-labs/serverless-api": "^3.1.0",
     "@twilio-labs/serverless-runtime-types": "^1.1.7",
     "@types/express": "^4.17.0",
     "@types/inquirer": "^6.0.3",

--- a/src/config/activate.ts
+++ b/src/config/activate.ts
@@ -9,7 +9,7 @@ import {
 } from '../commands/shared';
 import { getFullCommand } from '../commands/utils';
 import { readSpecializedConfig } from './global';
-import { getCredentialsFromFlags } from './utils';
+import { getCredentialsFromFlags, readLocalEnvFile, prepareEnvForDeploy } from './utils';
 import { mergeFlagsAndConfig } from './utils/mergeFlagsAndConfig';
 
 type ActivateConfig = ApiActivateConfig & {
@@ -61,6 +61,8 @@ export async function getConfigFromFlags(
     flags,
     externalCliOptions
   );
+  const { localEnv } = await readLocalEnvFile(flags);
+  const env = prepareEnvForDeploy(localEnv);
 
   const command = getFullCommand(flags);
   const serviceSid = checkForValidServiceSid(command, flags.serviceSid);
@@ -79,5 +81,6 @@ export async function getConfigFromFlags(
     sourceEnvironment: flags.sourceEnvironment,
     region,
     edge,
+    env
   };
 }

--- a/src/config/activate.ts
+++ b/src/config/activate.ts
@@ -9,7 +9,7 @@ import {
 } from '../commands/shared';
 import { getFullCommand } from '../commands/utils';
 import { readSpecializedConfig } from './global';
-import { getCredentialsFromFlags, readLocalEnvFile, prepareEnvForDeploy } from './utils';
+import { getCredentialsFromFlags, readLocalEnvFile, filterEnvVariablesForDeploy } from './utils';
 import { mergeFlagsAndConfig } from './utils/mergeFlagsAndConfig';
 
 type ActivateConfig = ApiActivateConfig & {
@@ -62,7 +62,7 @@ export async function getConfigFromFlags(
     externalCliOptions
   );
   const { localEnv } = await readLocalEnvFile(flags);
-  const env = prepareEnvForDeploy(localEnv);
+  const env = filterEnvVariablesForDeploy(localEnv);
 
   const command = getFullCommand(flags);
   const serviceSid = checkForValidServiceSid(command, flags.serviceSid);

--- a/src/config/deploy.ts
+++ b/src/config/deploy.ts
@@ -14,6 +14,7 @@ import {
   getServiceNameFromFlags,
   readLocalEnvFile,
   readPackageJsonContent,
+  prepareEnvForDeploy
 } from './utils';
 import { mergeFlagsAndConfig } from './utils/mergeFlagsAndConfig';
 
@@ -69,6 +70,7 @@ export async function getConfigFromFlags(
     externalCliOptions
   );
   const { localEnv, envPath } = await readLocalEnvFile(flags);
+  const env = prepareEnvForDeploy(localEnv);
 
   const serviceSid =
     flags.serviceSid ||
@@ -82,20 +84,6 @@ export async function getConfigFromFlags(
     ));
 
   const pkgJson = await readPackageJsonContent(flags);
-
-  const env = {
-    ...localEnv,
-  };
-
-  for (let key of Object.keys(env)) {
-    const val = env[key];
-    if (typeof val === 'string' && val.length === 0) {
-      delete env[key];
-    }
-  }
-
-  delete env.ACCOUNT_SID;
-  delete env.AUTH_TOKEN;
 
   let serviceName: string | undefined = await getServiceNameFromFlags(flags);
 

--- a/src/config/deploy.ts
+++ b/src/config/deploy.ts
@@ -14,7 +14,7 @@ import {
   getServiceNameFromFlags,
   readLocalEnvFile,
   readPackageJsonContent,
-  prepareEnvForDeploy
+  filterEnvVariablesForDeploy
 } from './utils';
 import { mergeFlagsAndConfig } from './utils/mergeFlagsAndConfig';
 
@@ -70,7 +70,7 @@ export async function getConfigFromFlags(
     externalCliOptions
   );
   const { localEnv, envPath } = await readLocalEnvFile(flags);
-  const env = prepareEnvForDeploy(localEnv);
+  const env = filterEnvVariablesForDeploy(localEnv);
 
   const serviceSid =
     flags.serviceSid ||

--- a/src/config/utils/env.ts
+++ b/src/config/utils/env.ts
@@ -27,7 +27,7 @@ export async function readLocalEnvFile(flags: {
   return { envPath: '', localEnv: {} };
 }
 
-export function prepareEnvForDeploy(localEnv: EnvironmentVariablesWithAuth): EnvironmentVariables {
+export function filterEnvVariablesForDeploy(localEnv: EnvironmentVariablesWithAuth): EnvironmentVariables {
   const env = {
     ...localEnv,
   };

--- a/src/config/utils/env.ts
+++ b/src/config/utils/env.ts
@@ -1,6 +1,7 @@
 import dotenv from 'dotenv';
 import path from 'path';
 import { EnvironmentVariablesWithAuth } from '../../types/generic';
+import { EnvironmentVariables } from '@twilio-labs/serverless-api';
 import { fileExists, readFile } from '../../utils/fs';
 
 export async function readLocalEnvFile(flags: {
@@ -24,4 +25,22 @@ export async function readLocalEnvFile(flags: {
     return { localEnv, envPath };
   }
   return { envPath: '', localEnv: {} };
+}
+
+export function prepareEnvForDeploy(localEnv: EnvironmentVariablesWithAuth): EnvironmentVariables {
+  const env = {
+    ...localEnv,
+  };
+
+  for (let key of Object.keys(env)) {
+    const val = env[key];
+    if (typeof val === 'string' && val.length === 0) {
+      delete env[key];
+    }
+  }
+
+  delete env.ACCOUNT_SID;
+  delete env.AUTH_TOKEN;
+
+  return env;
 }


### PR DESCRIPTION
The activate command wasn't passing any environment variables to the new environment. This should fix that along with [serverless-api#49](https://github.com/twilio-labs/serverless-api/pull/49).

Fixes: #109 


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
