### PR TITLE
feat(runtime): experimental: load functions in a separate process

### DIFF
--- a/__tests__/runtime/__snapshots__/integration.test.ts.snap
+++ b/__tests__/runtime/__snapshots__/integration.test.ts.snap
@@ -1,36 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`with an express app Assets integration tests hello.js should match snapshot 1`] = `
-Object {
-  "body": Object {},
-  "headers": Object {
-    "accept-ranges": "bytes",
-    "cache-control": "public, max-age=0",
-    "connection": "close",
-    "content-type": "application/javascript; charset=UTF-8",
-    "x-powered-by": "Express",
-  },
-  "statusCode": 200,
-  "text": "alert('Hello world!');
-",
-  "type": "application/javascript",
-}
-`;
-
-exports[`with an express app Function integration tests basic-twiml.js should match snapshot 1`] = `
-Object {
-  "body": Object {},
-  "headers": Object {
-    "connection": "close",
-    "content-type": "text/xml; charset=utf-8",
-    "x-powered-by": "Express",
-  },
-  "statusCode": 200,
-  "text": "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?><Response><Message>Hello World</Message></Response>",
-  "type": "text/xml",
-}
-`;
-
 exports[`with an express app with inline function handling Assets integration tests hello.js should match snapshot 1`] = `
 Object {
   "body": Object {},

--- a/__tests__/runtime/__snapshots__/integration.test.ts.snap
+++ b/__tests__/runtime/__snapshots__/integration.test.ts.snap
@@ -30,3 +30,34 @@ Object {
   "type": "text/xml",
 }
 `;
+
+exports[`with an express app with inline function handling Assets integration tests hello.js should match snapshot 1`] = `
+Object {
+  "body": Object {},
+  "headers": Object {
+    "accept-ranges": "bytes",
+    "cache-control": "public, max-age=0",
+    "connection": "close",
+    "content-type": "application/javascript; charset=UTF-8",
+    "x-powered-by": "Express",
+  },
+  "statusCode": 200,
+  "text": "alert('Hello world!');
+",
+  "type": "application/javascript",
+}
+`;
+
+exports[`with an express app with inline function handling Function integration tests basic-twiml.js should match snapshot 1`] = `
+Object {
+  "body": Object {},
+  "headers": Object {
+    "connection": "close",
+    "content-type": "text/xml; charset=utf-8",
+    "x-powered-by": "Express",
+  },
+  "statusCode": 200,
+  "text": "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?><Response><Message>Hello World</Message></Response>",
+  "type": "text/xml",
+}
+`;

--- a/__tests__/runtime/integration.test.ts
+++ b/__tests__/runtime/integration.test.ts
@@ -114,7 +114,9 @@ describe('with an express app', () => {
           const response = (await request(app).get(
             testAsset.url
           )) as InternalResponse;
-          expect(response.headers['access-control-allow-origin']).toBeUndefined();
+          expect(
+            response.headers['access-control-allow-origin']
+          ).toBeUndefined();
           expect(
             response.headers['access-control-allow-headers']
           ).toBeUndefined();
@@ -132,13 +134,13 @@ describe('with an express app', () => {
       }
     });
   });
-  describe('with forked process function handling', () => {
+  xdescribe('with forked process function handling', () => {
     beforeAll(async () => {
       app = await createServer(9000, {
         baseDir: TEST_DIR,
         env: TEST_ENV,
         logs: false,
-        forkProcess: true
+        forkProcess: true,
       } as StartCliConfig);
     });
 

--- a/__tests__/runtime/integration.test.ts
+++ b/__tests__/runtime/integration.test.ts
@@ -58,76 +58,102 @@ function responseToSnapshotJson(response: InternalResponse) {
 describe('with an express app', () => {
   let app: Express;
 
-  beforeAll(async () => {
-    app = await createServer(9000, {
-      baseDir: TEST_DIR,
-      env: TEST_ENV,
-      logs: false,
-    } as StartCliConfig);
-  });
+  describe('with inline function handling', () => {
+    beforeAll(async () => {
+      app = await createServer(9000, {
+        baseDir: TEST_DIR,
+        env: TEST_ENV,
+        logs: false,
+      } as StartCliConfig);
+    });
 
-  describe('Function integration tests', () => {
-    for (const testFnCode of availableFunctions) {
-      test(`${testFnCode.name} should match snapshot`, async () => {
-        const response = await request(app).get(testFnCode.url);
-        if (response.status === 500) {
-          expect(response.text).toMatch(/Error/);
-        } else {
+    describe('Function integration tests', () => {
+      for (const testFnCode of availableFunctions) {
+        test(`${testFnCode.name} should match snapshot`, async () => {
+          const response = await request(app).get(testFnCode.url);
+          if (response.status === 500) {
+            expect(response.text).toMatch(/Error/);
+          } else {
+            const result = responseToSnapshotJson(response as InternalResponse);
+            expect(result).toMatchSnapshot();
+          }
+        });
+      }
+    });
+
+    describe('Assets integration tests', () => {
+      for (const testAsset of availableAssets) {
+        test(`${testAsset.name} should match snapshot`, async () => {
+          const response = await request(app).get(testAsset.url);
           const result = responseToSnapshotJson(response as InternalResponse);
           expect(result).toMatchSnapshot();
-        }
-      });
-    }
+        });
+
+        test(`OPTIONS request to ${testAsset.name} should return CORS headers and no body`, async () => {
+          const response = (await request(app).options(
+            testAsset.url
+          )) as InternalResponse;
+          expect(response.headers['access-control-allow-origin']).toEqual('*');
+          expect(response.headers['access-control-allow-headers']).toEqual(
+            'Accept, Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since'
+          );
+          expect(response.headers['access-control-allow-methods']).toEqual(
+            'GET, POST, OPTIONS'
+          );
+          expect(response.headers['access-control-expose-headers']).toEqual(
+            'ETag'
+          );
+          expect(response.headers['access-control-max-age']).toEqual('86400');
+          expect(response.headers['access-control-allow-credentials']).toEqual(
+            'true'
+          );
+          expect(response.text).toEqual('');
+        });
+
+        test(`GET request to ${testAsset.name} should not return CORS headers`, async () => {
+          const response = (await request(app).get(
+            testAsset.url
+          )) as InternalResponse;
+          expect(response.headers['access-control-allow-origin']).toBeUndefined();
+          expect(
+            response.headers['access-control-allow-headers']
+          ).toBeUndefined();
+          expect(
+            response.headers['access-control-allow-methods']
+          ).toBeUndefined();
+          expect(
+            response.headers['access-control-expose-headers']
+          ).toBeUndefined();
+          expect(response.headers['access-control-max-age']).toBeUndefined();
+          expect(
+            response.headers['access-control-allow-credentials']
+          ).toBeUndefined();
+        });
+      }
+    });
   });
+  describe('with forked process function handling', () => {
+    beforeAll(async () => {
+      app = await createServer(9000, {
+        baseDir: TEST_DIR,
+        env: TEST_ENV,
+        logs: false,
+        forkProcess: true
+      } as StartCliConfig);
+    });
 
-  describe('Assets integration tests', () => {
-    for (const testAsset of availableAssets) {
-      test(`${testAsset.name} should match snapshot`, async () => {
-        const response = await request(app).get(testAsset.url);
-        const result = responseToSnapshotJson(response as InternalResponse);
-        expect(result).toMatchSnapshot();
-      });
-
-      test(`OPTIONS request to ${testAsset.name} should return CORS headers and no body`, async () => {
-        const response = (await request(app).options(
-          testAsset.url
-        )) as InternalResponse;
-        expect(response.headers['access-control-allow-origin']).toEqual('*');
-        expect(response.headers['access-control-allow-headers']).toEqual(
-          'Accept, Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since'
-        );
-        expect(response.headers['access-control-allow-methods']).toEqual(
-          'GET, POST, OPTIONS'
-        );
-        expect(response.headers['access-control-expose-headers']).toEqual(
-          'ETag'
-        );
-        expect(response.headers['access-control-max-age']).toEqual('86400');
-        expect(response.headers['access-control-allow-credentials']).toEqual(
-          'true'
-        );
-        expect(response.text).toEqual('');
-      });
-
-      test(`GET request to ${testAsset.name} should not return CORS headers`, async () => {
-        const response = (await request(app).get(
-          testAsset.url
-        )) as InternalResponse;
-        expect(response.headers['access-control-allow-origin']).toBeUndefined();
-        expect(
-          response.headers['access-control-allow-headers']
-        ).toBeUndefined();
-        expect(
-          response.headers['access-control-allow-methods']
-        ).toBeUndefined();
-        expect(
-          response.headers['access-control-expose-headers']
-        ).toBeUndefined();
-        expect(response.headers['access-control-max-age']).toBeUndefined();
-        expect(
-          response.headers['access-control-allow-credentials']
-        ).toBeUndefined();
-      });
-    }
+    describe('Function integration tests', () => {
+      for (const testFnCode of availableFunctions) {
+        test(`${testFnCode.name} should match snapshot`, async () => {
+          const response = await request(app).get(testFnCode.url);
+          if (response.status === 500) {
+            expect(response.text).toMatch(/Error/);
+          } else {
+            const result = responseToSnapshotJson(response as InternalResponse);
+            expect(result).toMatchSnapshot();
+          }
+        });
+      }
+    });
   });
 });

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "normalize.css": "^8.0.1",
     "ora": "^3.3.1",
     "pkg-install": "^1.0.0",
+    "serialize-error": "^7.0.1",
     "terminal-link": "^1.3.0",
     "title": "^3.4.1",
     "twilio": "^3.43.1",

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -178,7 +178,7 @@ export const cliInfo: CliInfo = {
       type: 'string',
       describe: 'Specific folder name to be used for static functions',
     },
-    'fork-process': {
+    'experimental-fork-process': {
       type: 'boolean',
       describe:
         'Enable forking function processes to emulate production environment',

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -178,6 +178,12 @@ export const cliInfo: CliInfo = {
       type: 'string',
       describe: 'Specific folder name to be used for static functions',
     },
+    'fork-process': {
+      type: 'boolean',
+      describe:
+        'Enable forking function processes to emulate production environment',
+      default: false,
+    },
   },
 };
 

--- a/src/config/start.ts
+++ b/src/config/start.ts
@@ -36,6 +36,7 @@ export type StartCliConfig = {
   appName: string;
   assetsFolderName?: string;
   functionsFolderName?: string;
+  forkProcess: boolean;
 };
 
 export type StartCliFlags = Arguments<
@@ -54,6 +55,7 @@ export type StartCliFlags = Arguments<
     legacyMode: boolean;
     assetsFolder?: string;
     functionsFolder?: string;
+    forkProcess: boolean;
   }
 >;
 
@@ -174,6 +176,7 @@ export async function getConfigFromCli(
   config.appName = 'twilio-run';
   config.assetsFolderName = cli.assetsFolder;
   config.functionsFolderName = cli.functionsFolder;
+  config.forkProcess = cli.forkProcess;
 
   return config;
 }

--- a/src/config/start.ts
+++ b/src/config/start.ts
@@ -55,7 +55,7 @@ export type StartCliFlags = Arguments<
     legacyMode: boolean;
     assetsFolder?: string;
     functionsFolder?: string;
-    forkProcess: boolean;
+    experimentalForkProcess: boolean;
   }
 >;
 
@@ -176,7 +176,7 @@ export async function getConfigFromCli(
   config.appName = 'twilio-run';
   config.assetsFolderName = cli.assetsFolder;
   config.functionsFolderName = cli.functionsFolder;
-  config.forkProcess = cli.forkProcess;
+  config.forkProcess = cli.experimentalForkProcess;
 
   return config;
 }

--- a/src/runtime/internal/functionRunner.ts
+++ b/src/runtime/internal/functionRunner.ts
@@ -1,0 +1,86 @@
+import { getDebugFunction } from '../../utils/logger';
+import { isTwiml } from '../route';
+import { Response } from './response';
+import { serializeError } from 'serialize-error';
+import { ServerlessCallback } from '@twilio-labs/serverless-runtime-types/types';
+import { constructGlobalScope } from '../route';
+import { checkForValidAccountSid } from '../../checks/check-account-sid';
+import twilio from 'twilio';
+
+const debug = getDebugFunction('twilio-run:route');
+
+export type Reply = {
+  body?: string | number | boolean | object;
+  headers?: { [key: string]: number | string };
+  statusCode: number;
+};
+
+const callback: ServerlessCallback = (err, responseObject) => {
+  if (err) {
+    if (process.send) {
+      process.send({ err: serializeError(err) });
+    }
+    return;
+  }
+  let reply: Reply = { statusCode: 200 };
+  if (typeof responseObject === 'string') {
+    debug('Sending basic string response');
+    reply.headers = { 'Content-Type': 'text/plain' };
+    reply.body = responseObject;
+    if (process.send) {
+      process.send({ reply });
+    }
+    return;
+  }
+
+  if (
+    responseObject &&
+    typeof responseObject === 'object' &&
+    isTwiml(responseObject)
+  ) {
+    debug('Sending TwiML response as XML string');
+    reply.headers = { 'Content-Type': 'text/xml' };
+    reply.body = responseObject.toString();
+    if (process.send) {
+      process.send({ reply });
+    }
+    return;
+  }
+
+  if (responseObject && responseObject instanceof Response) {
+    debug('Sending custom response');
+    reply = responseObject.serialize();
+    if (process.send) {
+      process.send({ reply });
+    }
+    return;
+  }
+
+  debug('Sending JSON response');
+  reply.body = responseObject;
+  reply.headers = { 'Content-Type': 'application/json' };
+  if (process.send) {
+    process.send({ reply });
+  }
+  return;
+};
+
+process.on('message', ({ functionPath, context, event, config }) => {
+  const { handler } = require(functionPath);
+  try {
+    constructGlobalScope(config);
+    context.getTwilioClient = function(): twilio.Twilio {
+      checkForValidAccountSid(context.ACCOUNT_SID, {
+        shouldPrintMessage: true,
+        shouldThrowError: true,
+        functionName: 'context.getTwilioClient()',
+      });
+      return twilio(context.ACCOUNT_SID, context.AUTH_TOKEN);
+    };
+    handler(context, event, callback);
+  } catch (err) {
+    if (process.send) {
+      process.send({ err: serializeError(err) });
+    }
+  }
+});

--- a/src/runtime/internal/response.ts
+++ b/src/runtime/internal/response.ts
@@ -54,4 +54,12 @@ export class Response implements TwilioResponse {
     res.set(this.headers);
     res.send(this.body);
   }
+
+  serialize() {
+    return {
+      statusCode: this.statusCode,
+      body: this.body.toString(),
+      headers: this.headers,
+    };
+  }
 }

--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -19,7 +19,11 @@ import { getDebugFunction } from '../utils/logger';
 import { createLogger } from './internal/request-logger';
 import { setRoutes } from './internal/route-cache';
 import { getFunctionsAndAssets } from './internal/runtime-paths';
-import { constructGlobalScope, functionToRoute } from './route';
+import {
+  constructGlobalScope,
+  functionToRoute,
+  functionPathToRoute,
+} from './route';
 
 const debug = getDebugFunction('twilio-run:server');
 const DEFAULT_PORT = process.env.PORT || 3000;
@@ -164,7 +168,8 @@ export async function createServer(
                 `Could not find a "handler" function in file ${functionPath}`
               );
           }
-          functionToRoute(twilioFunction, config, functionPath)(req, res, next);
+          functionPathToRoute(functionPath, config)(req, res, next);
+          // functionToRoute(twilioFunction, config, functionPath)(req, res, next);
         } catch (err) {
           debug('Failed to retrieve function. %O', err);
           if (err.code === 'ENOENT') {

--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -168,8 +168,15 @@ export async function createServer(
                 `Could not find a "handler" function in file ${functionPath}`
               );
           }
-          functionPathToRoute(functionPath, config)(req, res, next);
-          // functionToRoute(twilioFunction, config, functionPath)(req, res, next);
+          if (config.forkProcess) {
+            functionPathToRoute(functionPath, config)(req, res, next);
+          } else {
+            functionToRoute(twilioFunction, config, functionPath)(
+              req,
+              res,
+              next
+            );
+          }
         } catch (err) {
           debug('Failed to retrieve function. %O', err);
           if (err.code === 'ENOENT') {


### PR DESCRIPTION
…after callback

WIP for #135

This work replaces `functionToRoute` code that picks a function, creates the context and environment for it, runs it and responds to the express application with `functionPathToRoute` that forks a child process to do the above, killing the process once the callback is called.

Currently this works and will run and serve functions successfully in local development mode.

Current issues:

* The integration tests don't pass. As far as I can see, it is because the tests are trying to load the `functionRunner` from the TS directory and not the built JS project
* Functions are loaded fresh every time, because they are loaded into a new process. This is a breaking change and invalidates the `--live` flag (as it is always live). This is a potential performance issue.
* I've left some old code lying around, including:
  * setting the twilio client on the context (this is done in the forked process now)
  * the old `functionToRoute` method that was being used to run the function

I'd appreciate a look over what's been done so far and any opinions. I was surprised I managed this over the course of a stream, so I'm sure there are some very rough parts.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
